### PR TITLE
put back ascii diagram in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ The market account holds all relevant information. It begins with a header that 
 byte array after the header. There are 3 RedBlack trees for Bids, Asks,
 ClaimedSeats and 1 LinkedList for FreeListNodes, overlapping across each other. All are graphs where each vertex along with adjacency list fits in 80 bytes, allowing them to use the same blocks.
 
-## <pre>
-
-## | Header | Dynamic |
-
-## | BaseMint, QuoteMint, BidsRootIndex, ... | Bid | Ask | FreeListNode | Seat | Seat | Bid | Bid | Ask|
-
+<pre>
+--------------------------------------------------------------------------------------------------------
+|                   Header                    |                               Dynamic                   |
+--------------------------------------------------------------------------------------------------------
+| BaseMint, QuoteMint, BidsRootIndex, ...     | Bid | Ask | FreeListNode | Seat | Seat | Bid | Bid | Ask|
+--------------------------------------------------------------------------------------------------------
 </pre>
 
 ### Core vs Wrapper


### PR DESCRIPTION
<img width="1050" alt="Screenshot 2024-09-18 at 10 33 46 AM" src="https://github.com/user-attachments/assets/5d572396-9236-4e4c-811e-1ffc3e383562">

currently not rendering right