### PR TITLE
Reset createMarket to private

### DIFF
--- a/client/ts/src/client.ts
+++ b/client/ts/src/client.ts
@@ -450,7 +450,7 @@ export class ManifestClient {
    *
    * @returns TransactionInstruction
    */
-  public static createMarketIx(
+  private static createMarketIx(
     payer: PublicKey,
     baseMint: PublicKey,
     quoteMint: PublicKey,

--- a/debug-ui/app/create-market/page.tsx
+++ b/debug-ui/app/create-market/page.tsx
@@ -176,7 +176,7 @@ const CreateMarket = (): ReactElement => {
       },
     );
 
-    const createMarketIx = ManifestClient.createMarketIx(
+    const createMarketIx = ManifestClient['createMarketIx'](
       signerPub,
       basePub,
       quotePub,

--- a/debug-ui/scripts/run-rando-bot.ts
+++ b/debug-ui/scripts/run-rando-bot.ts
@@ -444,7 +444,7 @@ async function createMarket(
     ),
     programId: PROGRAM_ID,
   });
-  const createMarketIx = ManifestClient.createMarketIx(
+  const createMarketIx = ManifestClient['createMarketIx'](
     keypair.publicKey,
     baseMint,
     quoteMint,


### PR DESCRIPTION
This was intentional so it doesnt show up as public in autogenerated documentation and so it is not simple to do. We dont want excess redundant markets