### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Read [The Orderbook Manifesto](https://manifest.trade/whitepaper.pdf)
 | Read optimized| Yes | No | Yes |
 | Swap accounts| 16 | 8 | 7 |
 | [CU](https://cks-systems.github.io/manifest/dev/bench/) | :white_check_mark: | :white_check_mark: | :white_check_mark: :white_check_mark: |
-| Silent failures                                         | Yes                | Yes                | No                                    |
 | Token 22                                                | No                 | No                 | Yes                                   |
 | Composable wrapper                                      | No                 | No                 | Yes                                   |
 | Capital Efficient                                       | No                 | No                 | Yes                                   |
@@ -52,7 +51,6 @@ Read [The Orderbook Manifesto](https://manifest.trade/whitepaper.pdf)
 - Open orders separation was a necessary feature for margin trading. Read locks to get the open orders for a trader are frequent on a margin exchange. The default wrapper implementation of Manifest allows a margin exchange to read lock an account without significant contention and land its transactions more often.
 - Number of accounts for a swap is a limiter for some routers. Manifest swaps that do not use global orders achieve the theoretical minimum number of accounts.
 - CU is a major cost for market makers. Benchmarking demonstrates higher percentile CU improvements, significantly lessening the cost to actively trade.
-- Silent failures are an unfortunate feature request from market makers because of how solana transactions work. Manifest rejects this at the infra level, but still allows those who need it to handle in the wrapper.
 - Token 22 is the new version of token program. While it is not useful for defi and will make orderbooks less efficient, there are some notable tokens that will use it. Manifest only takes the performance hit to support token22 precisely when needed and moving token22 tokens, and only then.
 - A new core vs. wrapper program architecture enables greater composability for traders and exchange interfaces. Customize feature sets and distribution for any market requirement.
 - Capital efficient order type that allows market making on multiple markets while reusing capital across them.
@@ -90,6 +88,10 @@ Global orders are a new type of order for trading on Solana. When resting orders
 ```
 cargo build-sbf
 ```
+
+### Open Questions
+- Is tickless a good idea? This inverts time priority since it makes the most recent order able to provide negligible price improvement. This could disrupt behavior near mid and lead to unforeseen patterns.
+- Is global lock contention going to be a problem? Global provides capital efficiency that will be attractive to traders, but the extra lock contention for landing transactions, not only for placing a global, but also added to anyone who might match with it, may be problematic. There is a possibility that some markets may have restrictions on global usage to protect the land rates of normal traders.
 
 ### Testing
 


### PR DESCRIPTION
The removal of silent failures point is because it is more nuanced now with global handling. We still fail invalid orders rather than modify them, but in the case where it involves changes that could not be done in a wrapper, we handle as safely as we can. A wrapper is not able to add new accounts, just move orders