### PR TITLE
use non-deprecated method

### DIFF
--- a/client/ts/src/fillFeed.ts
+++ b/client/ts/src/fillFeed.ts
@@ -107,7 +107,9 @@ export class FillFeed {
    */
   private async handleSignature(signature: ConfirmedSignatureInfo) {
     console.log('Handling', signature.signature);
-    const tx = await this.connection.getTransaction(signature.signature)!;
+    const tx = await this.connection.getTransaction(signature.signature, {
+      maxSupportedTransactionVersion: 0,
+    });
     if (!tx?.meta?.logMessages) {
       console.log('No log messages');
       return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cks-systems/manifest-sdk",
-    "version": "0.1.56",
+    "version": "0.1.57",
     "files": [
         "dist/",
         "README.md",


### PR DESCRIPTION
I was getting errors when using getTransaction via helius. this update fixes that.