### PR TITLE
Reduce solana version requirement to make compatible with autobahn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 shank = "0.4.2"
 spl-token = { version = "=3.5.0", features = ["no-entrypoint"] }
 spl-token-2022 = { version = "3.0.4", features = [ "no-entrypoint" ] }
-solana-program = "1.18.1"
+solana-program = "1.17.29"
 borsh = "=0.9.3"
 bytemuck = "1.7.2"
 num_enum = "=0.5.11"


### PR DESCRIPTION
Autobahn requires
quic-geyser-common branch = "router_v1.17.29"
https://github.com/blockworks-foundation/autobahn/blob/2d8ada11178532910afccbeea037178f2f8de069/Cargo.toml#L30
which is locked on 1.17.29
https://github.com/blockworks-foundation/quic_geyser_plugin/blob/router_v1.17.29/Cargo.toml#L26