### PR TITLE
fix precision for displaying price in orderbook

### DIFF
--- a/client/ts/src/utils/numbers.ts
+++ b/client/ts/src/utils/numbers.ts
@@ -16,7 +16,7 @@ export function toNum(n: bignum): number {
   return target;
 }
 
-const BN_NUMBER_MAX = new BN(2 ** 53 - 1);
+const BN_NUMBER_MAX = new BN(2 ** 48 - 1);
 const BN_10 = new BN(10);
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cks-systems/manifest-sdk",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "files": [
     "dist/",
     "README.md",


### PR DESCRIPTION
There was problem with price display when you put limit order using methods from sdk e.g 170$ for SOL it will display as 169.9999 in orderbook this pr fix that lowering the max precision.