### PR TITLE
Fix old signatures on fill feed restart

### DIFF
--- a/client/ts/src/fillFeed.ts
+++ b/client/ts/src/fillFeed.ts
@@ -72,7 +72,7 @@ export class FillFeed {
   public async parseLogs(endEarly?: boolean) {
     // Start with a hopefully recent signature.
     let lastSignature: string | undefined = (
-      await this.connection.getSignaturesForAddress(PROGRAM_ID)
+      await this.connection.getSignaturesForAddress(PROGRAM_ID, { limit: 1 })
     )[0].signature;
 
     // End early is 30 seconds, used for testing.


### PR DESCRIPTION
Default right now is 1000 signatures and actually picks the oldest