### PR TITLE
Bring back a formal verification rule for cancel

### DIFF
--- a/programs/manifest/rules.json
+++ b/programs/manifest/rules.json
@@ -217,30 +217,6 @@
       "cargo_features": []
     },
     {
-      "name": "rule_swap_base_exact",
-      "expected_result": "Verified",
-      "prover_options": [],
-      "cargo_features": []
-    },
-    {
-      "name": "rule_swap_base_not_exact",
-      "expected_result": "Verified",
-      "prover_options": [],
-      "cargo_features": []
-    },
-    {
-      "name": "rule_swap_quote_exact",
-      "expected_result": "Verified",
-      "prover_options": [],
-      "cargo_features": []
-    },
-    {
-      "name": "rule_swap_quote_not_exact",
-      "expected_result": "Verified",
-      "prover_options": [],
-      "cargo_features": []
-    },
-    {
       "name": "rule_matching_if_maker_order_exists_bid",
       "expected_result": "Verified",
       "prover_options": [],

--- a/programs/manifest/rules.json
+++ b/programs/manifest/rules.json
@@ -73,6 +73,12 @@
       "cargo_features": []
     },
     {
+      "name": "rule_cancel_order_bid",
+      "expected_result": "Verified",
+      "prover_options": [],
+      "cargo_features": []
+    },
+    {
       "name": "rule_cancel_order_ask",
       "expected_result": "Verified",
       "prover_options": [],
@@ -206,6 +212,30 @@
     },
     {
       "name": "rule_integrity_of_batch_update_place_order_ask",
+      "expected_result": "Verified",
+      "prover_options": [],
+      "cargo_features": []
+    },
+    {
+      "name": "rule_swap_base_exact",
+      "expected_result": "Verified",
+      "prover_options": [],
+      "cargo_features": []
+    },
+    {
+      "name": "rule_swap_base_not_exact",
+      "expected_result": "Verified",
+      "prover_options": [],
+      "cargo_features": []
+    },
+    {
+      "name": "rule_swap_quote_exact",
+      "expected_result": "Verified",
+      "prover_options": [],
+      "cargo_features": []
+    },
+    {
+      "name": "rule_swap_quote_not_exact",
       "expected_result": "Verified",
       "prover_options": [],
       "cargo_features": []


### PR DESCRIPTION
Intentionally still removed:

assert( something that was never in spec ) is violated

rule_cancel_order_trader_integrity_bid
rule_cancel_order_trader_integrity_ask
rule_swap_internal_nodes_second_is_root
rule_swap_parent_left_child
rule_swap_right_child_parent
rule_swap_left_child_parent


Does not run on remote due to timeouts

rule_insert_preserves_parent_of_left_child
rule_insert_preserves_parent_of_right_child
rule_insert_preserves_root_parent_is_nil
rule_root_is_black_after_insert_non_empty_tree
rule_tree_is_ordered_after_insert_smallest_element


Does not run on remote due to
ScalarDomain error:cannot analyze SOL_MEMCPY on stack without knowing destination offset

rule_swap_base_exact
rule_swap_base_not_exact
rule_swap_quote_exact
rule_swap_quote_not_exact