### PR TITLE
Add cache for is22 in debug ui to help mitigate 429s

### DIFF
--- a/debug-ui/lib/util.ts
+++ b/debug-ui/lib/util.ts
@@ -98,10 +98,18 @@ export const checkForToken22 = async (
   conn: Connection,
   mint: PublicKey,
 ): Promise<boolean> => {
+  const localStorageKey: string = mint.toBase58() + '-Is22';
+
+  if (localStorage.getItem(localStorageKey)) {
+    return localStorage.getItem(localStorageKey)! === 'true';
+  }
+
   const acc = await conn.getAccountInfo(mint);
   if (!acc) {
     throw new Error('checkForToken22: account does not exist');
   }
 
-  return acc.owner.toBase58() !== TOKEN_PROGRAM_ID.toBase58();
+  const is22: boolean = acc.owner.toBase58() !== TOKEN_PROGRAM_ID.toBase58();
+  localStorage.setItem(localStorageKey, is22.toString());
+  return is22;
 };


### PR DESCRIPTION
Without this, we are spamming out 2 requests per market on page load for the landing page. This probably doesnt help on the first load, but should be helpful on follow up reloads