### PR TITLE
Fix: ESM build output was incorrect

### DIFF
--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,10 +1,11 @@
 {
-    "extends": "./tsconfig",
-    "compilerOptions": {
-      "declaration": false,
-      "declarationMap": false,
-      "module": "esnext",
-      "outDir": "dist/esm",
-      "sourceMap": false,
-    }
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "module": "esnext",
+    "outDir": "dist/esm",
+    "sourceMap": false
+  },
+  "include": ["client/ts/src"]
 }


### PR DESCRIPTION
Hi, we integrated the cks-systems/manifest package into our library and noticed that our users kept running into an issue when using it on the browser. We identified the root cause of the issue being the esm build of the cks-systems/manifest library being mis-referenced in your guys' package.json