### PR TITLE
fix: get_now_epoch() reads .slot instead of .epoch

### DIFF
--- a/programs/manifest/src/state/utils.rs
+++ b/programs/manifest/src/state/utils.rs
@@ -59,7 +59,7 @@ pub(crate) fn get_now_epoch() -> u64 {
             leader_schedule_epoch: u64::MAX,
             unix_timestamp: i64::MAX,
         })
-        .slot;
+        .epoch;
     now_epoch
 }
 


### PR DESCRIPTION
## Summary

`get_now_epoch()` in `programs/manifest/src/state/utils.rs:62` returns `Clock::get().slot` instead of `Clock::get().epoch`. This is a copy-paste from `get_now_slot()` directly above it (commit e33e49c1, Oct 2024).

## Impact

`get_epoch_fee(slot_number)` always selects `newer_transfer_fee` because the slot value (~300M+) always exceeds any epoch threshold (~700). This affects three call sites:

- **`utils.rs:301`** — global order transfer fee check (decides whether to block global fills)
- **`swap.rs:691`** — `calculate_post_fee_amount` on swap output
- **`swap.rs:750`** — `calculate_pre_fee_amount` on swap input

For Token-2022 mints where `older_transfer_fee` differs from `newer_transfer_fee`, the wrong fee schedule is applied. This is the same category of bug as the issues fixed in #531 and #554.

## Fix

One character: `.slot` → `.epoch` on line 62.

## How Certora missed it

The formal verification build (`#[cfg(feature = "certora")]`) stubs out all fee calculations with identity functions, so epoch-dependent fee schedules were never modeled.