### PR TITLE
global clean explpoit and fix

### DIFF
--- a/programs/manifest/src/program/processor/global_clean.rs
+++ b/programs/manifest/src/program/processor/global_clean.rs
@@ -107,7 +107,7 @@ pub(crate) fn process_global_clean(
     let required_global_atoms: u64 = if resting_order.get_is_bid() {
         resting_order
             .get_num_base_atoms()
-            .checked_mul(resting_order.get_price(), false)
+            .checked_mul(resting_order.get_price(), true)
             .unwrap()
             .as_u64()
     } else {
@@ -116,8 +116,7 @@ pub(crate) fn process_global_clean(
 
     require!(
         is_expired
-            || (resting_order.is_global()
-                && maker_global_balance.as_u64() < required_global_atoms),
+            || (resting_order.is_global() && maker_global_balance.as_u64() < required_global_atoms),
         crate::program::ManifestError::InvalidClean,
         "Ineligible clean order index {}",
         order_index,

--- a/programs/manifest/src/program/processor/global_clean.rs
+++ b/programs/manifest/src/program/processor/global_clean.rs
@@ -115,7 +115,9 @@ pub(crate) fn process_global_clean(
     };
 
     require!(
-        is_expired || maker_global_balance.as_u64() < required_global_atoms,
+        is_expired
+            || (resting_order.is_global()
+                && maker_global_balance.as_u64() < required_global_atoms),
         crate::program::ManifestError::InvalidClean,
         "Ineligible clean order index {}",
         order_index,

--- a/programs/manifest/tests/cases/exploit_global_clean.rs
+++ b/programs/manifest/tests/cases/exploit_global_clean.rs
@@ -1,0 +1,96 @@
+use std::rc::Rc;
+
+use hypertree::DataIndex;
+use manifest::{
+    program::{batch_update::PlaceOrderParams, global_clean_instruction},
+    state::{OrderType, RestingOrder, MARKET_BLOCK_SIZE, NO_EXPIRATION_LAST_VALID_SLOT},
+};
+use solana_program_test::tokio;
+use solana_sdk::signer::Signer;
+
+use crate::{send_tx_with_retry, TestFixture, Token};
+
+#[tokio::test]
+async fn third_party_clean_non_global_bid_is_rejected() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+
+    // Victim: claims a seat, deposits 100 USDC, places a permanent non-global
+    // bid for 100 SOL-atoms @ price 1.0
+    test_fixture.claim_seat().await?;
+    test_fixture.deposit(Token::USDC, 100).await?;
+    test_fixture
+        .batch_update_for_keypair(
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                100,
+                1,
+                0,
+                true,
+                OrderType::Limit,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            &test_fixture.payer_keypair().insecure_clone(),
+        )
+        .await?;
+
+    let orders_before: Vec<RestingOrder> = test_fixture.market_fixture.get_resting_orders().await;
+    assert_eq!(orders_before.len(), 1, "setup: expected one resting order");
+    
+    let victim_order: &RestingOrder = &orders_before[0];
+    assert_eq!(victim_order.get_order_type(), OrderType::Limit);
+    assert!(victim_order.get_is_bid());
+    assert!(
+        !victim_order.is_expired(u32::MAX - 1),
+        "order must not be expired - NO_EXPIRATION_LAST_VALID_SLOT",
+    );
+    assert_eq!(
+        test_fixture
+            .market_fixture
+            .get_quote_balance_atoms(&test_fixture.payer())
+            .await,
+        0,
+        "victim's free quote balance should be 0 (locked in order)",
+    );
+
+    // Attacker: unrelated to the victim (no seat, no global deposit).
+    let attacker = test_fixture.second_keypair.insecure_clone();
+    assert_ne!(attacker.pubkey(), test_fixture.payer());
+
+    // Attacker attempts `GlobalClean` on the victim's non-global bid using the
+    // quote-side global account (USDC). This MUST be rejected with InvalidClean.
+    let result = send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[global_clean_instruction(
+            &test_fixture.global_fixture.key,
+            &attacker.pubkey(),
+            &test_fixture.market_fixture.key,
+            MARKET_BLOCK_SIZE as DataIndex,
+        )],
+        Some(&attacker.pubkey()),
+        &[&attacker],
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "third-party GlobalClean on a permanent non-global bid must fail; got Ok",
+    );
+
+    // Order is still resting and the victim's backing quote is still locked.
+    let orders_after: Vec<RestingOrder> = test_fixture.market_fixture.get_resting_orders().await;
+    assert_eq!(
+        orders_after.len(),
+        1,
+        "victim's non-global bid must remain on the book after a rejected clean",
+    );
+    assert_eq!(
+        test_fixture
+            .market_fixture
+            .get_quote_balance_atoms(&test_fixture.payer())
+            .await,
+        0,
+        "victim's backing quote must remain locked in the order",
+    );
+
+    Ok(())
+}

--- a/programs/manifest/tests/cases/exploit_global_clean.rs
+++ b/programs/manifest/tests/cases/exploit_global_clean.rs
@@ -36,7 +36,7 @@ async fn third_party_clean_non_global_bid_is_rejected() -> anyhow::Result<()> {
 
     let orders_before: Vec<RestingOrder> = test_fixture.market_fixture.get_resting_orders().await;
     assert_eq!(orders_before.len(), 1, "setup: expected one resting order");
-    
+
     let victim_order: &RestingOrder = &orders_before[0];
     assert_eq!(victim_order.get_order_type(), OrderType::Limit);
     assert!(victim_order.get_is_bid());

--- a/programs/manifest/tests/cases/global.rs
+++ b/programs/manifest/tests/cases/global.rs
@@ -1107,7 +1107,9 @@ async fn maintenance_clean() -> anyhow::Result<()> {
     test_fixture.claim_seat().await?;
     test_fixture.global_add_trader().await?;
     test_fixture.deposit(Token::USDC, 100).await?;
+    test_fixture.global_deposit(1_000_000).await?;
 
+    // Assume 1_000 is sufficiently far enough that it is not already expired.
     test_fixture
         .batch_update_for_keypair(
             None,
@@ -1118,7 +1120,7 @@ async fn maintenance_clean() -> anyhow::Result<()> {
                 0,
                 true,
                 OrderType::Limit,
-                NO_EXPIRATION_LAST_VALID_SLOT,
+                1_000,
             )],
             &test_fixture.payer_keypair().insecure_clone(),
         )
@@ -1126,7 +1128,46 @@ async fn maintenance_clean() -> anyhow::Result<()> {
 
     test_fixture.advance_time_seconds(14 * 24 * 60 * 60).await;
 
-    // Clean should succeed.
+    // Clean should succeed because expired
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[global_clean_instruction(
+            &test_fixture.global_fixture.key,
+            &test_fixture.payer(),
+            &test_fixture.market_fixture.key,
+            MARKET_BLOCK_SIZE as DataIndex,
+        )],
+        Some(&test_fixture.payer()),
+        &[&test_fixture.payer_keypair().insecure_clone()],
+    )
+    .await?;
+
+    test_fixture.market_fixture.reload().await;
+
+    let bids = test_fixture.market_fixture.market.get_bids();
+    let next = bids.iter::<RestingOrder>().next();
+    assert_eq!(next, None);
+
+    test_fixture
+        .batch_update_with_global_for_keypair(
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                100,
+                1,
+                0,
+                true,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            &test_fixture.payer_keypair().insecure_clone(),
+        )
+        .await?;
+
+    // Unback the global.
+    test_fixture.global_withdraw(1_000_000).await?;
+
+    // Clean should succeed because unbacked
     send_tx_with_retry(
         Rc::clone(&test_fixture.context),
         &[global_clean_instruction(

--- a/programs/manifest/tests/cases/mod.rs
+++ b/programs/manifest/tests/cases/mod.rs
@@ -3,6 +3,7 @@ pub mod cancel_order;
 pub mod claim_seat;
 pub mod create_market;
 pub mod deposit;
+pub mod exploit_global_clean;
 pub mod exploit_global_reduce;
 pub mod global;
 pub mod loaders;


### PR DESCRIPTION
This can only be used to close arbitrary orders - funds can not be drained otherwise I would not have disclosed it here