### PR TITLE
Add market maker monitoring alerts

### DIFF
--- a/scripts/stats-server.ts
+++ b/scripts/stats-server.ts
@@ -10,7 +10,6 @@ import promBundle from 'express-prom-bundle';
 import {
   VOLUME_CHECKPOINT_DURATION_SEC,
   DATABASE_CHECKPOINT_DURATION_SEC,
-  ONE_HOUR_SEC,
   ONE_DAY_SEC,
   ONE_HOUR_SEC,
   PORT,
@@ -487,6 +486,19 @@ const run = async () => {
           await statsServer.checkHourlyVolumeChange();
         } catch (error) {
           console.error('Error in hourly volume check:', error);
+          await sleep(5_000);
+        }
+      }
+    })(),
+    // Hourly market maker monitoring - alerts on new market makers and large volume changes
+    (async () => {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        try {
+          await sleep(ONE_HOUR_SEC * 1_000);
+          await statsServer.checkHourlyMarketMakerChanges();
+        } catch (error) {
+          console.error('Error in market maker monitoring:', error);
           await sleep(5_000);
         }
       }

--- a/scripts/stats_utils/manifestStatsServer.ts
+++ b/scripts/stats_utils/manifestStatsServer.ts
@@ -46,6 +46,7 @@ import { withRetry } from './utils';
 import { WebSocketManager } from './websocketManager';
 import { parseTransactionForFills } from './backfill';
 import { VolumeMonitor } from './volumeMonitor';
+import { MarketMakerMonitor } from './marketMakerMonitor';
 
 // Memory management constants
 const MAX_TRADERS = 50000; // Maximum number of traders to track in memory
@@ -153,6 +154,9 @@ export class ManifestStatsServer {
   // Volume monitoring for alerts
   private volumeMonitor: VolumeMonitor;
 
+  // Market maker monitoring for alerts
+  private marketMakerMonitor: MarketMakerMonitor;
+
   constructor(
     rpcUrl: string,
     isReadOnly: boolean,
@@ -198,9 +202,16 @@ export class ManifestStatsServer {
     // Initialize volume monitor for alerts
     this.volumeMonitor = new VolumeMonitor(
       this.discordWebhookUrl,
-      () => this.getSolPrice(),
-      (marketPk: string) => this.markets.get(marketPk),
-      (marketPk: string) => this.tickers.get(marketPk),
+      (): number => this.getSolPrice(),
+      (marketPk: string): Market | undefined => this.markets.get(marketPk),
+      (marketPk: string): [string, string] | undefined =>
+        this.tickers.get(marketPk),
+    );
+
+    // Initialize market maker monitor
+    this.marketMakerMonitor = new MarketMakerMonitor(
+      this.discordWebhookUrl,
+      (): Map<string, number> => this.traderMakerNotionalVolume,
     );
   }
 
@@ -225,6 +236,14 @@ export class ManifestStatsServer {
    */
   async checkHourlyVolumeChange(): Promise<void> {
     await this.volumeMonitor.checkHourlyVolumeChange();
+  }
+
+  /**
+   * Check for new market makers and large maker volume changes.
+   * Should be called every hour.
+   */
+  async checkHourlyMarketMakerChanges(): Promise<void> {
+    await this.marketMakerMonitor.checkHourlyChanges();
   }
 
   private initTraderPositionTracking(trader: string): void {

--- a/scripts/stats_utils/marketMakerMonitor.ts
+++ b/scripts/stats_utils/marketMakerMonitor.ts
@@ -3,8 +3,17 @@ import { sendDiscordNotification } from './utils';
 // Threshold for new market maker alert (in USDC equivalent)
 const NEW_MARKET_MAKER_THRESHOLD_USDC: number = 100_000;
 
-// Large hourly volume threshold for existing market makers ($1 million)
+// Threshold for $1M lifetime volume milestone
+const MILLION_MAKER_THRESHOLD_USDC: number = 1_000_000;
+
+// Large hourly volume threshold ($1 million in one hour)
 const MAKER_HOURLY_VOLUME_THRESHOLD_USDC: number = 1_000_000;
+
+// Percentage change threshold for hourly volume (50%)
+const MAKER_VOLUME_CHANGE_PERCENT_THRESHOLD: number = 0.5;
+
+// Minimum volume to track for percentage-based change alerts
+const MIN_VOLUME_FOR_PERCENT_ALERT_USDC: number = 50_000;
 
 // Type for hourly maker volume snapshot
 interface MakerVolumeSnapshot {
@@ -16,8 +25,11 @@ export class MarketMakerMonitor {
   private readonly discordWebhookUrl: string | undefined;
   private previousSnapshot: MakerVolumeSnapshot | null = null;
 
-  // Set of traders who have already been alerted as new market makers
+  // Set of traders who have already been alerted as new market makers ($100k)
   private alertedNewMarketMakers: Set<string> = new Set();
+
+  // Set of traders who have already been alerted for $1M milestone
+  private alertedMillionMakers: Set<string> = new Set();
 
   // Callback to get current maker volumes from stats server
   private readonly getMakerVolumes: () => Map<string, number>;
@@ -48,8 +60,8 @@ export class MarketMakerMonitor {
       return;
     }
 
-    // Check for new market makers crossing the threshold
-    await this.checkNewMarketMakers(currentVolumes);
+    // Check for new market makers crossing thresholds
+    await this.checkMarketMakerMilestones(currentVolumes);
 
     // Check for large volume changes in existing market makers
     await this.checkVolumeChanges(
@@ -61,16 +73,25 @@ export class MarketMakerMonitor {
   }
 
   /**
-   * Check for traders who have crossed the new market maker threshold
+   * Check for traders who have crossed market maker milestones ($100k, $1M)
    */
-  private async checkNewMarketMakers(
+  private async checkMarketMakerMilestones(
     currentVolumes: Map<string, number>,
   ): Promise<void> {
     for (const [trader, volume] of currentVolumes) {
+      // Check $100k threshold (new market maker)
       if (volume >= NEW_MARKET_MAKER_THRESHOLD_USDC) {
         if (!this.alertedNewMarketMakers.has(trader)) {
           this.alertedNewMarketMakers.add(trader);
           await this.sendNewMarketMakerAlert(trader, volume);
+        }
+      }
+
+      // Check $1M threshold (million maker milestone)
+      if (volume >= MILLION_MAKER_THRESHOLD_USDC) {
+        if (!this.alertedMillionMakers.has(trader)) {
+          this.alertedMillionMakers.add(trader);
+          await this.sendMillionMakerAlert(trader, volume);
         }
       }
     }
@@ -89,20 +110,40 @@ export class MarketMakerMonitor {
       // Calculate hourly volume (delta)
       const hourlyVolume: number = currentVolume - previousVolume;
 
+      // Skip if no activity this hour
+      if (hourlyVolume <= 0) {
+        continue;
+      }
+
       // Alert if hourly volume exceeds $1 million threshold
       if (hourlyVolume >= MAKER_HOURLY_VOLUME_THRESHOLD_USDC) {
-        await this.sendVolumeChangeAlert(
+        await this.sendLargeHourlyVolumeAlert(
+          trader,
+          currentVolume,
+          hourlyVolume,
+        );
+        continue; // Don't also send percentage alert for same trader
+      }
+
+      // Alert if hourly volume is 50%+ of previous total (for traders with $50k+ volume)
+      if (
+        previousVolume >= MIN_VOLUME_FOR_PERCENT_ALERT_USDC &&
+        hourlyVolume / previousVolume >= MAKER_VOLUME_CHANGE_PERCENT_THRESHOLD
+      ) {
+        const percentChange: number = hourlyVolume / previousVolume;
+        await this.sendPercentChangeAlert(
           trader,
           previousVolume,
           currentVolume,
           hourlyVolume,
+          percentChange,
         );
       }
     }
   }
 
   /**
-   * Send alert for new market maker
+   * Send alert for new market maker ($100k threshold)
    */
   private async sendNewMarketMakerAlert(
     trader: string,
@@ -122,18 +163,44 @@ export class MarketMakerMonitor {
     ].join('\n');
 
     await sendDiscordNotification(this.discordWebhookUrl, message, {
-      title: '🏦 New Market Maker',
+      title: '🏦 New Market Maker ($100K)',
       color: 0x00ff00,
       timestamp: true,
     });
   }
 
   /**
-   * Send alert for large volume change
+   * Send alert for $1M lifetime volume milestone
    */
-  private async sendVolumeChangeAlert(
+  private async sendMillionMakerAlert(
     trader: string,
-    previousVolume: number,
+    volume: number,
+  ): Promise<void> {
+    if (!this.discordWebhookUrl) {
+      return;
+    }
+
+    const formattedVolume: string = this.formatUsdValue(volume);
+
+    const message: string = [
+      `**Market maker crossed $1M lifetime volume**`,
+      `Trader: \`${trader.slice(0, 8)}...${trader.slice(-4)}\``,
+      `Maker Volume: ${formattedVolume}`,
+      `[View on Solscan](https://solscan.io/account/${trader})`,
+    ].join('\n');
+
+    await sendDiscordNotification(this.discordWebhookUrl, message, {
+      title: '🎉 Million Dollar Market Maker',
+      color: 0x9932cc,
+      timestamp: true,
+    });
+  }
+
+  /**
+   * Send alert for large hourly volume ($1M+ in one hour)
+   */
+  private async sendLargeHourlyVolumeAlert(
+    trader: string,
     currentVolume: number,
     hourlyVolume: number,
   ): Promise<void> {
@@ -142,10 +209,40 @@ export class MarketMakerMonitor {
     }
 
     const message: string = [
-      `**Large maker volume in last hour**`,
+      `**$1M+ maker volume in last hour**`,
       `Trader: \`${trader.slice(0, 8)}...${trader.slice(-4)}\``,
       `Hourly Volume: +${this.formatUsdValue(hourlyVolume)}`,
       `Total Volume: ${this.formatUsdValue(currentVolume)}`,
+      `[View on Solscan](https://solscan.io/account/${trader})`,
+    ].join('\n');
+
+    await sendDiscordNotification(this.discordWebhookUrl, message, {
+      title: '📈 Massive Hourly Volume',
+      color: 0xff4500,
+      timestamp: true,
+    });
+  }
+
+  /**
+   * Send alert for 50%+ hourly volume increase
+   */
+  private async sendPercentChangeAlert(
+    trader: string,
+    previousVolume: number,
+    currentVolume: number,
+    hourlyVolume: number,
+    percentChange: number,
+  ): Promise<void> {
+    if (!this.discordWebhookUrl) {
+      return;
+    }
+
+    const message: string = [
+      `**Large maker volume increase**`,
+      `Trader: \`${trader.slice(0, 8)}...${trader.slice(-4)}\``,
+      `Previous Total: ${this.formatUsdValue(previousVolume)}`,
+      `Current Total: ${this.formatUsdValue(currentVolume)}`,
+      `Hourly Volume: +${this.formatUsdValue(hourlyVolume)} (+${(percentChange * 100).toFixed(1)}%)`,
       `[View on Solscan](https://solscan.io/account/${trader})`,
     ].join('\n');
 
@@ -179,6 +276,9 @@ export class MarketMakerMonitor {
     for (const [trader, volume] of volumes) {
       if (volume >= NEW_MARKET_MAKER_THRESHOLD_USDC) {
         this.alertedNewMarketMakers.add(trader);
+      }
+      if (volume >= MILLION_MAKER_THRESHOLD_USDC) {
+        this.alertedMillionMakers.add(trader);
       }
     }
   }

--- a/scripts/stats_utils/marketMakerMonitor.ts
+++ b/scripts/stats_utils/marketMakerMonitor.ts
@@ -1,0 +1,208 @@
+import { sendDiscordNotification } from './utils';
+
+// Threshold for new market maker alert (in USDC equivalent)
+const NEW_MARKET_MAKER_THRESHOLD_USDC: number = 100_000;
+
+// Large change threshold for existing market makers (50%)
+const MAKER_VOLUME_CHANGE_THRESHOLD: number = 0.5;
+
+// Minimum volume to track for large changes (avoid noise from small traders)
+const MIN_VOLUME_FOR_CHANGE_ALERT_USDC: number = 50_000;
+
+// Type for hourly maker volume snapshot
+interface MakerVolumeSnapshot {
+  timestamp: number;
+  volumeByTrader: Map<string, number>;
+}
+
+export class MarketMakerMonitor {
+  private readonly discordWebhookUrl: string | undefined;
+  private previousSnapshot: MakerVolumeSnapshot | null = null;
+
+  // Set of traders who have already been alerted as new market makers
+  private alertedNewMarketMakers: Set<string> = new Set();
+
+  // Callback to get current maker volumes from stats server
+  private readonly getMakerVolumes: () => Map<string, number>;
+
+  constructor(
+    discordWebhookUrl: string | undefined,
+    getMakerVolumes: () => Map<string, number>,
+  ) {
+    this.discordWebhookUrl = discordWebhookUrl;
+    this.getMakerVolumes = getMakerVolumes;
+  }
+
+  /**
+   * Check for new market makers and large volume changes.
+   * Should be called every hour.
+   */
+  async checkHourlyChanges(): Promise<void> {
+    const currentVolumes: Map<string, number> = new Map(this.getMakerVolumes());
+    const currentSnapshot: MakerVolumeSnapshot = {
+      timestamp: Date.now(),
+      volumeByTrader: currentVolumes,
+    };
+
+    // On first run, initialize existing market makers to avoid false alerts
+    if (!this.previousSnapshot) {
+      this.initializeExistingMarketMakers(currentVolumes);
+      this.previousSnapshot = currentSnapshot;
+      return;
+    }
+
+    // Check for new market makers crossing the threshold
+    await this.checkNewMarketMakers(currentVolumes);
+
+    // Check for large volume changes in existing market makers
+    await this.checkVolumeChanges(
+      this.previousSnapshot.volumeByTrader,
+      currentVolumes,
+    );
+
+    this.previousSnapshot = currentSnapshot;
+  }
+
+  /**
+   * Check for traders who have crossed the new market maker threshold
+   */
+  private async checkNewMarketMakers(
+    currentVolumes: Map<string, number>,
+  ): Promise<void> {
+    for (const [trader, volume] of currentVolumes) {
+      if (volume >= NEW_MARKET_MAKER_THRESHOLD_USDC) {
+        if (!this.alertedNewMarketMakers.has(trader)) {
+          this.alertedNewMarketMakers.add(trader);
+          await this.sendNewMarketMakerAlert(trader, volume);
+        }
+      }
+    }
+  }
+
+  /**
+   * Check for large volume changes in existing market makers
+   */
+  private async checkVolumeChanges(
+    previousVolumes: Map<string, number>,
+    currentVolumes: Map<string, number>,
+  ): Promise<void> {
+    for (const [trader, currentVolume] of currentVolumes) {
+      const previousVolume: number = previousVolumes.get(trader) ?? 0;
+
+      // Skip if below minimum threshold for change alerts
+      if (
+        currentVolume < MIN_VOLUME_FOR_CHANGE_ALERT_USDC &&
+        previousVolume < MIN_VOLUME_FOR_CHANGE_ALERT_USDC
+      ) {
+        continue;
+      }
+
+      // Calculate hourly volume (delta)
+      const hourlyVolume: number = currentVolume - previousVolume;
+
+      // Skip if no significant activity this hour
+      if (hourlyVolume <= 0) {
+        continue;
+      }
+
+      // Check for large percentage change relative to previous total
+      if (previousVolume > 0) {
+        const percentChange: number = hourlyVolume / previousVolume;
+
+        if (percentChange >= MAKER_VOLUME_CHANGE_THRESHOLD) {
+          await this.sendVolumeChangeAlert(
+            trader,
+            previousVolume,
+            currentVolume,
+            hourlyVolume,
+            percentChange,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Send alert for new market maker
+   */
+  private async sendNewMarketMakerAlert(
+    trader: string,
+    volume: number,
+  ): Promise<void> {
+    if (!this.discordWebhookUrl) {
+      return;
+    }
+
+    const formattedVolume: string = this.formatUsdValue(volume);
+
+    const message: string = [
+      `**New market maker detected**`,
+      `Trader: \`${trader.slice(0, 8)}...${trader.slice(-4)}\``,
+      `Maker Volume: ${formattedVolume}`,
+      `[View on Solscan](https://solscan.io/account/${trader})`,
+    ].join('\n');
+
+    await sendDiscordNotification(this.discordWebhookUrl, message, {
+      title: '🏦 New Market Maker',
+      color: 0x00ff00,
+      timestamp: true,
+    });
+  }
+
+  /**
+   * Send alert for large volume change
+   */
+  private async sendVolumeChangeAlert(
+    trader: string,
+    previousVolume: number,
+    currentVolume: number,
+    hourlyVolume: number,
+    percentChange: number,
+  ): Promise<void> {
+    if (!this.discordWebhookUrl) {
+      return;
+    }
+
+    const message: string = [
+      `**Large maker volume increase**`,
+      `Trader: \`${trader.slice(0, 8)}...${trader.slice(-4)}\``,
+      `Previous Total: ${this.formatUsdValue(previousVolume)}`,
+      `Current Total: ${this.formatUsdValue(currentVolume)}`,
+      `Hourly Volume: +${this.formatUsdValue(hourlyVolume)} (+${(percentChange * 100).toFixed(1)}%)`,
+      `[View on Solscan](https://solscan.io/account/${trader})`,
+    ].join('\n');
+
+    await sendDiscordNotification(this.discordWebhookUrl, message, {
+      title: '📈 Market Maker Volume Spike',
+      color: 0xffd700,
+      timestamp: true,
+    });
+  }
+
+  /**
+   * Format USD value with appropriate suffix (K, M, B)
+   */
+  private formatUsdValue(value: number): string {
+    if (value >= 1_000_000_000) {
+      return `$${(value / 1_000_000_000).toFixed(2)}B`;
+    }
+    if (value >= 1_000_000) {
+      return `$${(value / 1_000_000).toFixed(2)}M`;
+    }
+    if (value >= 1_000) {
+      return `$${(value / 1_000).toFixed(2)}K`;
+    }
+    return `$${value.toFixed(2)}`;
+  }
+
+  /**
+   * Initialize with existing market makers to avoid false alerts on startup
+   */
+  initializeExistingMarketMakers(volumes: Map<string, number>): void {
+    for (const [trader, volume] of volumes) {
+      if (volume >= NEW_MARKET_MAKER_THRESHOLD_USDC) {
+        this.alertedNewMarketMakers.add(trader);
+      }
+    }
+  }
+}

--- a/scripts/stats_utils/marketMakerMonitor.ts
+++ b/scripts/stats_utils/marketMakerMonitor.ts
@@ -3,11 +3,8 @@ import { sendDiscordNotification } from './utils';
 // Threshold for new market maker alert (in USDC equivalent)
 const NEW_MARKET_MAKER_THRESHOLD_USDC: number = 100_000;
 
-// Large change threshold for existing market makers (50%)
-const MAKER_VOLUME_CHANGE_THRESHOLD: number = 0.5;
-
-// Minimum volume to track for large changes (avoid noise from small traders)
-const MIN_VOLUME_FOR_CHANGE_ALERT_USDC: number = 50_000;
+// Large hourly volume threshold for existing market makers ($1 million)
+const MAKER_HOURLY_VOLUME_THRESHOLD_USDC: number = 1_000_000;
 
 // Type for hourly maker volume snapshot
 interface MakerVolumeSnapshot {
@@ -89,35 +86,17 @@ export class MarketMakerMonitor {
     for (const [trader, currentVolume] of currentVolumes) {
       const previousVolume: number = previousVolumes.get(trader) ?? 0;
 
-      // Skip if below minimum threshold for change alerts
-      if (
-        currentVolume < MIN_VOLUME_FOR_CHANGE_ALERT_USDC &&
-        previousVolume < MIN_VOLUME_FOR_CHANGE_ALERT_USDC
-      ) {
-        continue;
-      }
-
       // Calculate hourly volume (delta)
       const hourlyVolume: number = currentVolume - previousVolume;
 
-      // Skip if no significant activity this hour
-      if (hourlyVolume <= 0) {
-        continue;
-      }
-
-      // Check for large percentage change relative to previous total
-      if (previousVolume > 0) {
-        const percentChange: number = hourlyVolume / previousVolume;
-
-        if (percentChange >= MAKER_VOLUME_CHANGE_THRESHOLD) {
-          await this.sendVolumeChangeAlert(
-            trader,
-            previousVolume,
-            currentVolume,
-            hourlyVolume,
-            percentChange,
-          );
-        }
+      // Alert if hourly volume exceeds $1 million threshold
+      if (hourlyVolume >= MAKER_HOURLY_VOLUME_THRESHOLD_USDC) {
+        await this.sendVolumeChangeAlert(
+          trader,
+          previousVolume,
+          currentVolume,
+          hourlyVolume,
+        );
       }
     }
   }
@@ -157,18 +136,16 @@ export class MarketMakerMonitor {
     previousVolume: number,
     currentVolume: number,
     hourlyVolume: number,
-    percentChange: number,
   ): Promise<void> {
     if (!this.discordWebhookUrl) {
       return;
     }
 
     const message: string = [
-      `**Large maker volume increase**`,
+      `**Large maker volume in last hour**`,
       `Trader: \`${trader.slice(0, 8)}...${trader.slice(-4)}\``,
-      `Previous Total: ${this.formatUsdValue(previousVolume)}`,
-      `Current Total: ${this.formatUsdValue(currentVolume)}`,
-      `Hourly Volume: +${this.formatUsdValue(hourlyVolume)} (+${(percentChange * 100).toFixed(1)}%)`,
+      `Hourly Volume: +${this.formatUsdValue(hourlyVolume)}`,
+      `Total Volume: ${this.formatUsdValue(currentVolume)}`,
       `[View on Solscan](https://solscan.io/account/${trader})`,
     ].join('\n');
 


### PR DESCRIPTION
- Alert when new market makers cross $100k maker volume threshold
- Alert when existing market makers have >50% hourly volume increase
- Run hourly in stats server alongside TVL and volume monitoring