### PR TITLE
Harden TypeScript validator tests

### DIFF
--- a/client/ts/tests/batchUpdate.ts
+++ b/client/ts/tests/batchUpdate.ts
@@ -13,6 +13,7 @@ import { Market } from '../src/market';
 import { assert } from 'chai';
 import { depositGlobal } from './globalDeposit';
 import { createGlobal } from './createGlobal';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testBatchUpdate(): Promise<void> {
   const connection: Connection = new Connection(
@@ -142,7 +143,7 @@ async function batchUpdate(
   console.log(`Placed order in ${signature}`);
 }
 
-describe('Batch update test', () => {
+describeIfDirectTest(module, 'Batch update test', () => {
   it('BatchUpdate', async () => {
     await testBatchUpdate();
   });

--- a/client/ts/tests/cancelAllOnCore.ts
+++ b/client/ts/tests/cancelAllOnCore.ts
@@ -12,6 +12,7 @@ import { deposit } from './deposit';
 import { placeOrder } from './placeOrder';
 import { Market } from '../src/market';
 import { assert } from 'chai';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testCancelAllOnCore(): Promise<void> {
   // Setup connection and accounts
@@ -141,7 +142,7 @@ export async function cancelAllOnCore(
   }
 }
 
-describe('Cancel All On Core Test', () => {
+describeIfDirectTest(module, 'Cancel All On Core Test', () => {
   it('Should cancel all reverse orders on the core program', async () => {
     await testCancelAllOnCore();
   });

--- a/client/ts/tests/cancelBidsAsksOnCore.ts
+++ b/client/ts/tests/cancelBidsAsksOnCore.ts
@@ -12,6 +12,7 @@ import { deposit } from './deposit';
 import { placeOrder } from './placeOrder';
 import { Market } from '../src/market';
 import { assert } from 'chai';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testCancelBidsAsksOnCore(): Promise<void> {
   // Setup connection and accounts
@@ -274,7 +275,7 @@ export async function cancelAsksOnCore(
   }
 }
 
-describe('Cancel Bids/Asks On Core Test', () => {
+describeIfDirectTest(module, 'Cancel Bids/Asks On Core Test', () => {
   it('Should cancel bid and ask orders separately on the core program', async () => {
     await testCancelBidsAsksOnCore();
   });

--- a/client/ts/tests/cancelOrder.ts
+++ b/client/ts/tests/cancelOrder.ts
@@ -12,6 +12,7 @@ import { deposit } from './deposit';
 import { placeOrder } from './placeOrder';
 import { Market } from '../src/market';
 import { assert } from 'chai';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testCancelOrder(): Promise<void> {
   const connection: Connection = new Connection(
@@ -141,7 +142,7 @@ export async function cancelOrder(
   console.log(`Canceled order in ${signature}`);
 }
 
-describe('Cancel test', () => {
+describeIfDirectTest(module, 'Cancel test', () => {
   it('Place and cancel orders', async () => {
     await testCancelOrder();
   });

--- a/client/ts/tests/claimSeat.ts
+++ b/client/ts/tests/claimSeat.ts
@@ -3,6 +3,7 @@ import { ManifestClient } from '../src/client';
 import { createMarket } from './createMarket';
 import { Market } from '../src/market';
 import { assert } from 'chai';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testClaimSeat(): Promise<void> {
   const connection: Connection = new Connection(
@@ -68,7 +69,7 @@ export async function claimSeat(
   await ManifestClient.getClientForMarket(connection, market, payerKeypair);
 }
 
-describe('Claim Seat test', () => {
+describeIfDirectTest(module, 'Claim Seat test', () => {
   it('Claim seat', async () => {
     await testClaimSeat();
   });

--- a/client/ts/tests/createClient.ts
+++ b/client/ts/tests/createClient.ts
@@ -8,6 +8,7 @@ import {
 import { createMarket } from './createMarket';
 import { ManifestClient } from '../src';
 import { assert } from 'chai';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testGetClientForMarketNoPrivateKey(
   connection: Connection,
@@ -82,40 +83,50 @@ async function testGetSetupIxs(
   console.log(`executed setupIxs: ${signature}`);
 }
 
-describe('when creating a client using getClientForMarketNoPrivateKey', () => {
-  let connection: Connection;
-  let payerKeypair: Keypair;
-  let marketAddress: PublicKey;
+describeIfDirectTest(
+  module,
+  'when creating a client using getClientForMarketNoPrivateKey',
+  () => {
+    let connection: Connection;
+    let payerKeypair: Keypair;
+    let marketAddress: PublicKey;
 
-  before(async () => {
-    connection = new Connection('http://127.0.0.1:8899', 'confirmed');
-    payerKeypair = Keypair.generate();
-    marketAddress = await createMarket(connection, payerKeypair);
-  });
+    before(async () => {
+      connection = new Connection('http://127.0.0.1:8899', 'confirmed');
+      payerKeypair = Keypair.generate();
+      marketAddress = await createMarket(connection, payerKeypair);
+    });
 
-  it('should crash if setupIxs NOT executed', async () => {
-    await testGetClientForMarketNoPrivateKey(
-      connection,
-      marketAddress,
-      payerKeypair,
-      true,
-    );
-  });
+    it('should crash if setupIxs NOT executed', async () => {
+      await testGetClientForMarketNoPrivateKey(
+        connection,
+        marketAddress,
+        payerKeypair,
+        true,
+      );
+    });
 
-  it('should get setupIxs using getSetupIxs and execute successfully', async () => {
-    await testGetSetupIxs(connection, marketAddress, payerKeypair, true, true);
-  });
+    it('should get setupIxs using getSetupIxs and execute successfully', async () => {
+      await testGetSetupIxs(
+        connection,
+        marketAddress,
+        payerKeypair,
+        true,
+        true,
+      );
+    });
 
-  it('should wait 15 seconds to let state catch up', async () => {
-    await new Promise((resolve) => setTimeout(resolve, 15_000));
-  });
+    it('should wait 15 seconds to let state catch up', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 15_000));
+    });
 
-  it('should NOT crash if setupIxs already executed', async () => {
-    await testGetClientForMarketNoPrivateKey(
-      connection,
-      marketAddress,
-      payerKeypair,
-      false,
-    );
-  });
-});
+    it('should NOT crash if setupIxs already executed', async () => {
+      await testGetClientForMarketNoPrivateKey(
+        connection,
+        marketAddress,
+        payerKeypair,
+        false,
+      );
+    });
+  },
+);

--- a/client/ts/tests/createGlobal.ts
+++ b/client/ts/tests/createGlobal.ts
@@ -10,9 +10,13 @@ import { Global } from '../src/global';
 import { airdropSol, getClusterFromConnection } from '../src/utils/solana';
 import { createMint } from '@solana/spl-token';
 import { getGlobalAddress } from '../src/utils/global';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testCreateGlobal(): Promise<void> {
-  const connection: Connection = new Connection('http://127.0.0.1:8899');
+  const connection: Connection = new Connection(
+    'http://127.0.0.1:8899',
+    'confirmed',
+  );
   const payerKeypair: Keypair = Keypair.generate();
   // Get SOL for rent.
   await airdropSol(connection, payerKeypair.publicKey);
@@ -68,7 +72,7 @@ export async function createGlobal(
   console.log(`Created global for ${tokenMint} in ${signature}`);
 }
 
-describe('Create Global test', () => {
+describeIfDirectTest(module, 'Create Global test', () => {
   it('Create Global', async () => {
     await testCreateGlobal();
   });

--- a/client/ts/tests/createMarket.ts
+++ b/client/ts/tests/createMarket.ts
@@ -13,6 +13,7 @@ import { Market } from '../src/market';
 import { airdropSol, getClusterFromConnection } from '../src/utils/solana';
 import { createMint } from '@solana/spl-token';
 import { FIXED_MANIFEST_HEADER_SIZE } from '../src/constants';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testCreateMarket(): Promise<void> {
   const connection: Connection = new Connection(
@@ -82,7 +83,7 @@ export async function createMarket(
   return marketKeypair.publicKey;
 }
 
-describe('Create Market test', () => {
+describeIfDirectTest(module, 'Create Market test', () => {
   it('Create Market', async () => {
     await testCreateMarket();
   });

--- a/client/ts/tests/deposit.ts
+++ b/client/ts/tests/deposit.ts
@@ -14,6 +14,8 @@ import {
 import { createMarket } from './createMarket';
 import { Market } from '../src/market';
 import { assert } from 'chai';
+import { waitForTokenAccount } from './helpers/tokenAccount';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testDeposit(): Promise<void> {
   const connection: Connection = new Connection(
@@ -66,6 +68,7 @@ export async function deposit(
     mint,
     payerKeypair.publicKey,
   );
+  await waitForTokenAccount(connection, traderTokenAccount);
 
   const mintDecimals = (await getMint(connection, mint)).decimals;
   const amountAtoms = Math.ceil(amountTokens * 10 ** mintDecimals);
@@ -89,7 +92,7 @@ export async function deposit(
   console.log(`Deposited ${amountTokens} tokens in ${signature}`);
 }
 
-describe('Deposit test', () => {
+describeIfDirectTest(module, 'Deposit test', () => {
   it('Deposit', async () => {
     await testDeposit();
   });

--- a/client/ts/tests/depositPlaceOrder.ts
+++ b/client/ts/tests/depositPlaceOrder.ts
@@ -16,6 +16,8 @@ import {
   createAssociatedTokenAccountIdempotent,
   mintTo,
 } from '@solana/spl-token';
+import { waitForTokenAccount } from './helpers/tokenAccount';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testDepositPlaceOrder(): Promise<void> {
   const connection: Connection = new Connection(
@@ -49,6 +51,7 @@ async function testDepositPlaceOrder(): Promise<void> {
     market.quoteMint(),
     payerKeypair.publicKey,
   );
+  await waitForTokenAccount(connection, traderTokenAccount);
   const quoteSize = 3;
   const quotePrice = 3;
   const quoteNotional = quotePrice * quoteSize;
@@ -148,7 +151,7 @@ export async function depositPlaceOrder(
   console.log(`Required Deposit and Placed order in ${signature}`);
 }
 
-describe('Deposit Place Order test', () => {
+describeIfDirectTest(module, 'Deposit Place Order test', () => {
   it('Deposit Place Order', async () => {
     await testDepositPlaceOrder();
   });

--- a/client/ts/tests/expired.ts
+++ b/client/ts/tests/expired.ts
@@ -5,6 +5,7 @@ import { deposit } from './deposit';
 import { Market } from '../src/market';
 import { assert } from 'chai';
 import { placeOrder } from './placeOrder';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testExpiredAsk(): Promise<void> {
   const connection: Connection = new Connection(
@@ -39,7 +40,7 @@ async function testExpiredAsk(): Promise<void> {
   }
 }
 
-describe('Expired Order test', () => {
+describeIfDirectTest(module, 'Expired Order test', () => {
   it('Expired Ask', async () => {
     await testExpiredAsk();
   });

--- a/client/ts/tests/fillFeed.ts
+++ b/client/ts/tests/fillFeed.ts
@@ -7,6 +7,7 @@ import { assert } from 'chai';
 import { FillFeed } from '../src/fillFeed';
 import { placeOrder } from './placeOrder';
 import WebSocket from 'ws';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testFillFeed(): Promise<void> {
   const connection: Connection = new Connection(
@@ -88,7 +89,7 @@ async function checkForFillMessage(
   ws.close();
 }
 
-describe('FillListener test', () => {
+describeIfDirectTest(module, 'FillListener test', () => {
   it('FillListener', async () => {
     await testFillFeed();
   });

--- a/client/ts/tests/globalDeposit.ts
+++ b/client/ts/tests/globalDeposit.ts
@@ -18,9 +18,14 @@ import { Global } from '../src/global';
 import { assert } from 'chai';
 import { getGlobalAddress } from '../src/utils/global';
 import { airdropSol } from '../src/utils/solana';
+import { waitForTokenAccount } from './helpers/tokenAccount';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testGlobalDeposit(): Promise<void> {
-  const connection: Connection = new Connection('http://127.0.0.1:8899');
+  const connection: Connection = new Connection(
+    'http://127.0.0.1:8899',
+    'confirmed',
+  );
   const payerKeypair: Keypair = Keypair.generate();
   // Get SOL for rent.
   await airdropSol(connection, payerKeypair.publicKey);
@@ -85,6 +90,7 @@ export async function depositGlobal(
       mint,
       traderKeypair.publicKey,
     );
+  await waitForTokenAccount(connection, traderTokenAccount);
 
   const mintDecimals: number = (await getMint(connection, mint)).decimals;
   const amountAtoms: number = Math.ceil(amountTokens * 10 ** mintDecimals);
@@ -113,7 +119,7 @@ export async function depositGlobal(
   );
 }
 
-describe('Global Deposit test', () => {
+describeIfDirectTest(module, 'Global Deposit test', () => {
   it('Global Deposit', async () => {
     await testGlobalDeposit();
   });

--- a/client/ts/tests/globalWithdraw.ts
+++ b/client/ts/tests/globalWithdraw.ts
@@ -13,9 +13,13 @@ import { assert } from 'chai';
 import { getGlobalAddress } from '../src/utils/global';
 import { createMint } from '@solana/spl-token';
 import { airdropSol } from '../src/utils/solana';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testGlobalWithdraw(): Promise<void> {
-  const connection: Connection = new Connection('http://127.0.0.1:8899');
+  const connection: Connection = new Connection(
+    'http://127.0.0.1:8899',
+    'confirmed',
+  );
   const payerKeypair: Keypair = Keypair.generate();
   // Get SOL for rent.
   await airdropSol(connection, payerKeypair.publicKey);
@@ -76,7 +80,7 @@ export async function withdrawGlobal(
   console.log(`Global Withdrew ${amountTokens} tokens in ${signature}`);
 }
 
-describe('Global Withdraw test', () => {
+describeIfDirectTest(module, 'Global Withdraw test', () => {
   it('Global Withdraw', async () => {
     await testGlobalWithdraw();
   });

--- a/client/ts/tests/helpers/mocha.ts
+++ b/client/ts/tests/helpers/mocha.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+
+const TESTS_DIR = path.resolve(__dirname, '..');
+
+function isTestFile(filename: string | undefined): boolean {
+  return filename != null && path.resolve(filename).startsWith(TESTS_DIR);
+}
+
+export function describeIfDirectTest(
+  currentModule: NodeModule,
+  title: string,
+  fn: (this: Mocha.Suite) => void,
+): Mocha.Suite | void {
+  if (!isTestFile(currentModule.parent?.filename)) {
+    return describe(title, fn);
+  }
+}

--- a/client/ts/tests/helpers/tokenAccount.ts
+++ b/client/ts/tests/helpers/tokenAccount.ts
@@ -1,0 +1,27 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { getAccount, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+
+const TOKEN_ACCOUNT_RETRIES = 10;
+const TOKEN_ACCOUNT_RETRY_DELAY_MS = 200;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitForTokenAccount(
+  connection: Connection,
+  tokenAccount: PublicKey,
+  tokenProgramId: PublicKey = TOKEN_PROGRAM_ID,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < TOKEN_ACCOUNT_RETRIES; attempt++) {
+    try {
+      await getAccount(connection, tokenAccount, 'confirmed', tokenProgramId);
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(TOKEN_ACCOUNT_RETRY_DELAY_MS);
+    }
+  }
+  throw lastError;
+}

--- a/client/ts/tests/killSwitchMarket.ts
+++ b/client/ts/tests/killSwitchMarket.ts
@@ -6,6 +6,7 @@ import { Market } from '../src/market';
 import { assert } from 'chai';
 import { placeOrder } from './placeOrder';
 import { OrderType } from '../src/manifest/types';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testKillSwitchMarket(): Promise<void> {
   const connection: Connection = new Connection(
@@ -84,7 +85,7 @@ export async function killSwitchMarketOO(
   );
 }
 
-describe('Kill Switch Market test', () => {
+describeIfDirectTest(module, 'Kill Switch Market test', () => {
   it('KillSwitchMarket', async () => {
     await testKillSwitchMarket();
   });

--- a/client/ts/tests/listMarkets.ts
+++ b/client/ts/tests/listMarkets.ts
@@ -3,6 +3,7 @@ import { ManifestClient } from '../src/client';
 import { Market } from '../src/market';
 import { assert } from 'chai';
 import { createMarket } from './createMarket';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testListMarket(): Promise<void> {
   const connection: Connection = new Connection(
@@ -26,7 +27,7 @@ async function testListMarket(): Promise<void> {
   assert(marketPks[0].toBase58() == marketAddress.toBase58());
 }
 
-describe('List Market test', () => {
+describeIfDirectTest(module, 'List Market test', () => {
   it('List Market', async () => {
     await testListMarket();
   });

--- a/client/ts/tests/market.ts
+++ b/client/ts/tests/market.ts
@@ -7,6 +7,7 @@ import { placeOrder } from './placeOrder';
 import { OrderType } from '../src/manifest';
 import { deposit } from './deposit';
 import { areFloatsEqual } from './utils';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function setupMarketState(): Promise<Market> {
   const connection: Connection = new Connection(
@@ -158,7 +159,7 @@ async function testMarket(): Promise<void> {
   market.prettyPrint();
 }
 
-describe('Market test', () => {
+describeIfDirectTest(module, 'Market test', () => {
   let market: Market;
   let connection: Connection;
 

--- a/client/ts/tests/mixedWrappers.ts
+++ b/client/ts/tests/mixedWrappers.ts
@@ -31,6 +31,8 @@ import {
 } from '@cks-systems/manifest-sdk-old/dist/cjs/ui_wrapper';
 import { UiWrapper } from '@cks-systems/manifest-sdk-old/dist/cjs/uiWrapperObj';
 import { Market as OldMarket } from '@cks-systems/manifest-sdk-old/dist/cjs/market';
+import { waitForTokenAccount } from './helpers/tokenAccount';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testMixedWrappers(): Promise<void> {
   const connection: Connection = new Connection(
@@ -106,6 +108,7 @@ async function testMixedWrappers(): Promise<void> {
     baseMint,
     payerKeypair.publicKey,
   );
+  await waitForTokenAccount(connection, traderBaseTokenAccount);
   const baseMintDecimals = (await getMint(connection, baseMint)).decimals;
   const amountBaseAtoms = Math.ceil(100 * 10 ** baseMintDecimals);
   await mintTo(
@@ -240,7 +243,7 @@ async function testMixedWrappers(): Promise<void> {
   market.prettyPrint();
 }
 
-describe('Mixed Wrappers test', () => {
+describeIfDirectTest(module, 'Mixed Wrappers test', () => {
   it('Should allow same wallet to use both UI wrapper and normal wrapper', async () => {
     await testMixedWrappers();
   });

--- a/client/ts/tests/placeOrder.ts
+++ b/client/ts/tests/placeOrder.ts
@@ -13,6 +13,7 @@ import { deposit } from './deposit';
 import { Market } from '../src/market';
 import { assert } from 'chai';
 import { NO_EXPIRATION_LAST_VALID_SLOT } from '../src/constants';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testPlaceOrder(): Promise<void> {
   const connection: Connection = new Connection(
@@ -111,7 +112,7 @@ export async function placeOrder(
   console.log(`Placed order in ${signature}`);
 }
 
-describe('Place Order test', () => {
+describeIfDirectTest(module, 'Place Order test', () => {
   it('Place Order', async () => {
     await testPlaceOrder();
   });

--- a/client/ts/tests/reverse.ts
+++ b/client/ts/tests/reverse.ts
@@ -5,6 +5,7 @@ import { deposit } from './deposit';
 import { Market } from '../src/market';
 import { assert } from 'chai';
 import { placeOrder } from './placeOrder';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testReverse(): Promise<void> {
   const connection: Connection = new Connection(
@@ -87,7 +88,7 @@ async function testReverse(): Promise<void> {
   );
 }
 
-describe('Reverse test', () => {
+describeIfDirectTest(module, 'Reverse test', () => {
   it('Reverse', async () => {
     await testReverse();
   });

--- a/client/ts/tests/swap.ts
+++ b/client/ts/tests/swap.ts
@@ -21,6 +21,8 @@ import { depositGlobal } from './globalDeposit';
 import { createGlobal } from './createGlobal';
 import { OrderType } from '../src/manifest/types';
 import { NO_EXPIRATION_LAST_VALID_SLOT } from '../src/constants';
+import { waitForTokenAccount } from './helpers/tokenAccount';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testSwap(): Promise<void> {
   const connection: Connection = new Connection(
@@ -48,6 +50,7 @@ async function testSwap(): Promise<void> {
     market.quoteMint(),
     payerKeypair.publicKey,
   );
+  await waitForTokenAccount(connection, traderTokenAccount);
 
   const amountAtoms: number = 1_000_000_000;
   const mintSig = await mintTo(
@@ -127,6 +130,7 @@ async function testSwapGlobal(): Promise<void> {
     market.quoteMint(),
     payerKeypair.publicKey,
   );
+  await waitForTokenAccount(connection, traderBaseTokenAccount);
 
   const amountBaseAtoms: number = 1_000_000_000;
   const mintSig: string = await mintTo(
@@ -206,7 +210,7 @@ async function testSwapGlobal(): Promise<void> {
   );
 }
 
-describe('Swap test', () => {
+describeIfDirectTest(module, 'Swap test', () => {
   it('Swap', async () => {
     await testSwap();
   });

--- a/client/ts/tests/utils.ts
+++ b/client/ts/tests/utils.ts
@@ -2,6 +2,7 @@ import { Connection } from '@solana/web3.js';
 import { assert } from 'chai';
 import { getClusterFromConnection } from '../src/utils/solana';
 import { toMantissaAndExponent } from '../src';
+import { describeIfDirectTest } from './helpers/mocha';
 
 export const areFloatsEqual = (
   num1: number,
@@ -37,7 +38,7 @@ function testToMantissaAndExponent(): void {
   );
 }
 
-describe('Utils test', () => {
+describeIfDirectTest(module, 'Utils test', () => {
   it('Utils', async () => {
     await testUtils();
   });

--- a/client/ts/tests/volume.ts
+++ b/client/ts/tests/volume.ts
@@ -7,9 +7,13 @@ import { Market } from '../src/market';
 import { assert } from 'chai';
 import { placeOrder } from './placeOrder';
 import { WrapperMarketInfo, Wrapper } from '../src';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testVolume(): Promise<void> {
-  const connection: Connection = new Connection('http://127.0.0.1:8899');
+  const connection: Connection = new Connection(
+    'http://127.0.0.1:8899',
+    'confirmed',
+  );
   const payerKeypair: Keypair = Keypair.generate();
 
   const marketAddress: PublicKey = await createMarket(connection, payerKeypair);
@@ -71,7 +75,7 @@ async function testVolume(): Promise<void> {
   );
 }
 
-describe('Volume test', () => {
+describeIfDirectTest(module, 'Volume test', () => {
   it('Volume', async () => {
     await testVolume();
   });

--- a/client/ts/tests/withdraw.ts
+++ b/client/ts/tests/withdraw.ts
@@ -10,6 +10,7 @@ import { createMarket } from './createMarket';
 import { deposit } from './deposit';
 import { Market } from '../src/market';
 import { assert } from 'chai';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testWithdraw(): Promise<void> {
   const connection: Connection = new Connection(
@@ -65,7 +66,7 @@ export async function withdraw(
   console.log(`Withdrew ${amountTokens} tokens in ${signature}`);
 }
 
-describe('Withdraw test', () => {
+describeIfDirectTest(module, 'Withdraw test', () => {
   it('Withdraw', async () => {
     await testWithdraw();
   });

--- a/client/ts/tests/wrapper.ts
+++ b/client/ts/tests/wrapper.ts
@@ -21,6 +21,7 @@ import {
 import { Wrapper } from '../src/wrapperObj';
 import { FIXED_WRAPPER_HEADER_SIZE } from '../src/constants';
 import { airdropSol } from '../src/utils/solana';
+import { describeIfDirectTest } from './helpers/mocha';
 
 async function testWrapper(): Promise<void> {
   const connection: Connection = new Connection(
@@ -151,7 +152,7 @@ async function testWrapper(): Promise<void> {
   );
 }
 
-describe('Wrapper test', () => {
+describeIfDirectTest(module, 'Wrapper test', () => {
   it('Wrapper', async () => {
     await testWrapper();
   });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "validate": "yarn lint && yarn format",
     "prepare": "yarn build",
     "clean": "rm -rf dist",
-    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' nyc  --reporter=lcov ts-mocha client/ts/tests/*.ts --parallel --jobs 64 --timeout 1200000"
+    "test": "TS_NODE_PROJECT='./tsconfig.cjs.json' nyc --reporter=lcov ts-mocha client/ts/tests/*.ts --parallel --jobs ${TS_MOCHA_JOBS:-8} --timeout 1200000"
   },
   "dependencies": {
     "@metaplex-foundation/beet": "^0.7.1",


### PR DESCRIPTION
## Summary
- add `describeIfDirectTest` so helper-imported test files do not register duplicate suites
- add token-account polling for validator consistency
- reduce default TS mocha parallelism via `TS_MOCHA_JOBS`

## Verification
- `yarn -s tsc --noEmit -p tsconfig.cjs.json`