### PR TITLE
Pin Certora CLI version

### DIFF
--- a/.github/workflows/ci-certora.yml
+++ b/.github/workflows/ci-certora.yml
@@ -27,7 +27,7 @@ jobs:
           ecosystem: solana
           working-directory: programs/manifest/src/certora/confs
           certora-key: ${{ secrets.CERTORAKEY }}
+          cli-version: "8.11.3"
           certora-sbf-options: "-vvv --tools-version=v1.43"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
## Summary
- pin the Certora GitHub Action CLI to `8.11.3` for reproducible verification runs

## Verification
- not run; workflow-only change