### PR TITLE
Fix Cargo profile and feature warnings

### DIFF
--- a/programs/manifest/Cargo.toml
+++ b/programs/manifest/Cargo.toml
@@ -24,23 +24,6 @@ certora = ["no-entrypoint", "dep:cvt", "dep:nondet", "dep:cvt-macros", "dep:earl
            "hypertree/certora", "dep:cvlr"]
 certora_vacuity = ["cvt/vacuity"]
 
-
-# https://doc.rust-lang.org/cargo/reference/profiles.html
-[profile.release]
-lto = "fat"
-codegen-units = 1
-overflow-checks = true
-strip = "debuginfo"
-
-# Test with release settings so CU usage is accurately measured.
-[profile.test]
-lto = "fat"
-opt-level = 3
-debug = false
-codegen-units = 1
-overflow-checks = true
-strip = "debuginfo"
-
 [dependencies]
 hypertree = { path = "../../lib" }
 # Cannot use workspace because the generator needs to see a version here

--- a/programs/ui-wrapper/Cargo.toml
+++ b/programs/ui-wrapper/Cargo.toml
@@ -14,9 +14,10 @@ name = "ui_wrapper"
 [features]
 no-entrypoint = []
 cpi = ["no-entrypoint"]
-default = ["trace"] 
+default = ["trace"]
 trace = [ "hypertree/fuzz", "hypertree/trace", "manifest-dex/trace" ]
 test = []
+test-sbf = []
 
 [dependencies]
 manifest-dex = { path = "../manifest", features = ["no-entrypoint"]  }

--- a/programs/wrapper/Cargo.toml
+++ b/programs/wrapper/Cargo.toml
@@ -17,6 +17,7 @@ cpi = ["no-entrypoint"]
 default = []
 trace = [ "manifest-dex/trace" ]
 test = []
+test-sbf = []
 
 [dependencies]
 manifest-dex = { path = "../manifest", features = ["no-entrypoint"]  }


### PR DESCRIPTION
- Remove duplicate profile sections from programs/manifest/Cargo.toml (profiles should only be at workspace root)
- Add missing test-sbf feature to ui-wrapper and wrapper packages