### PR TITLE
Fix all Rust warnings

### DIFF
--- a/.github/workflows/ci-code-review-rust.yml
+++ b/.github/workflows/ci-code-review-rust.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Set Rust version
         run: |
           rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
+          rustup default ${{ env.RUST_TOOLCHAIN }}
           rustup component add rustfmt
 
       - name: Run fmt

--- a/.github/workflows/ci-code-review-rust.yml
+++ b/.github/workflows/ci-code-review-rust.yml
@@ -29,12 +29,11 @@ jobs:
 
       - name: Set Rust version
         run: |
-          rustup toolchain install ${{ env.RUST_TOOLCHAIN }}
-          rustup default ${{ env.RUST_TOOLCHAIN }}
-          rustup component add rustfmt
+          rustup toolchain install nightly
+          rustup component add rustfmt --toolchain nightly
 
       - name: Run fmt
-        run: cargo fmt -- --check
+        run: cargo +nightly fmt -- --check
 
   clippy:
     name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,13 @@ members = [
   "programs/ui-wrapper",
 ]
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(colored)',
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("certora-test", "custom-panic", "custom-heap", "fuzz"))',
+] }
+
 [workspace.dependencies]
 shank = "0.4.2"
 spl-token = { version = "8.0.0", features = ["no-entrypoint"] }

--- a/client/okx/Cargo.toml
+++ b/client/okx/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Britt Cyr <britt@cks.systems>"]
 description = "OKX AMM interface for Manifest exchange"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [features]
 test = []
 

--- a/client/rust/jup/Cargo.toml
+++ b/client/rust/jup/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Britt Cyr <britt@manifest.trade>"]
 description = "Jupiter AMM interface for Manifest exchange"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [features]
 test = []
 

--- a/client/rust/slim/Cargo.toml
+++ b/client/rust/slim/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Britt Cyr <britt@manifest.trade>"]
 description = "Minimal dependency Manifest client for instruction building and market parsing"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [features]
 default = []
 

--- a/client/rust/slim/src/constants.rs
+++ b/client/rust/slim/src/constants.rs
@@ -3,8 +3,7 @@
 use solana_pubkey::Pubkey;
 
 // Re-export types from hypertree
-pub use hypertree::DataIndex;
-pub use hypertree::NIL;
+pub use hypertree::{DataIndex, NIL};
 
 /// Order type enum for placing and parsing orders.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/client/rust/slim/src/events.rs
+++ b/client/rust/slim/src/events.rs
@@ -3,8 +3,7 @@
 //! These are the log events that can be parsed from transaction logs.
 //! Each event has an 8-byte discriminant prefix followed by the struct data.
 
-use crate::constants::OrderType;
-use crate::Pubkey;
+use crate::{constants::OrderType, Pubkey};
 
 /// Boolean type that is Pod-compatible (1 byte).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/client/rust/slim/src/instruction.rs
+++ b/client/rust/slim/src/instruction.rs
@@ -1,13 +1,10 @@
 //! Instruction builders for Manifest operations.
 
-use crate::constants::DataIndex;
-use crate::constants::OrderType;
-use crate::constants::MANIFEST_PROGRAM_ID;
-use crate::constants::NO_EXPIRATION_LAST_VALID_SLOT;
-use crate::constants::SYSTEM_PROGRAM_ID;
-use crate::constants::TOKEN_PROGRAM_ID;
-use solana_instruction::AccountMeta;
-use solana_instruction::Instruction;
+use crate::constants::{
+    DataIndex, OrderType, MANIFEST_PROGRAM_ID, NO_EXPIRATION_LAST_VALID_SLOT, SYSTEM_PROGRAM_ID,
+    TOKEN_PROGRAM_ID,
+};
+use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
 
 /// Manifest instruction discriminants.

--- a/client/rust/slim/src/lib.rs
+++ b/client/rust/slim/src/lib.rs
@@ -8,88 +8,42 @@ mod events;
 mod instruction;
 mod state;
 
-pub use solana_instruction::AccountMeta;
-pub use solana_instruction::Instruction;
+pub use solana_instruction::{AccountMeta, Instruction};
 pub use solana_pubkey::Pubkey;
 
-pub use constants::DataIndex;
-pub use constants::OrderType;
-pub use constants::CLAIMED_SEAT_SIZE;
-pub use constants::MANIFEST_PROGRAM_ID;
-pub use constants::MARKET_BLOCK_SIZE;
-pub use constants::MARKET_FIXED_DISCRIMINANT;
-pub use constants::MARKET_FIXED_SIZE;
-pub use constants::NIL;
-pub use constants::NO_EXPIRATION_LAST_VALID_SLOT;
-pub use constants::RESTING_ORDER_SIZE;
-pub use constants::SYSTEM_PROGRAM_ID;
-pub use constants::TOKEN_2022_PROGRAM_ID;
-pub use constants::TOKEN_PROGRAM_ID;
+pub use constants::{
+    DataIndex, OrderType, CLAIMED_SEAT_SIZE, MANIFEST_PROGRAM_ID, MARKET_BLOCK_SIZE,
+    MARKET_FIXED_DISCRIMINANT, MARKET_FIXED_SIZE, NIL, NO_EXPIRATION_LAST_VALID_SLOT,
+    RESTING_ORDER_SIZE, SYSTEM_PROGRAM_ID, TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID,
+};
 
-pub use instruction::batch_update_instruction;
-pub use instruction::batch_update_with_global_instruction;
-pub use instruction::claim_seat_instruction;
-pub use instruction::create_market_instruction;
-pub use instruction::deposit_instruction;
-pub use instruction::expand_instruction;
-pub use instruction::get_global_address;
-pub use instruction::get_global_vault_address;
-pub use instruction::get_vault_address;
-pub use instruction::swap_instruction;
-pub use instruction::withdraw_instruction;
-pub use instruction::BatchUpdateParams;
-pub use instruction::CancelOrderParams;
-pub use instruction::DepositParams;
-pub use instruction::ManifestInstruction;
-pub use instruction::PlaceOrderParams;
-pub use instruction::SwapParams;
-pub use instruction::WithdrawParams;
+pub use instruction::{
+    batch_update_instruction, batch_update_with_global_instruction, claim_seat_instruction,
+    create_market_instruction, deposit_instruction, expand_instruction, get_global_address,
+    get_global_vault_address, get_vault_address, swap_instruction, withdraw_instruction,
+    BatchUpdateParams, CancelOrderParams, DepositParams, ManifestInstruction, PlaceOrderParams,
+    SwapParams, WithdrawParams,
+};
 
-pub use state::ClaimedSeat;
-pub use state::Market;
-pub use state::MarketFixed;
-pub use state::OrderIterator;
-pub use state::RBNodeHeader;
-pub use state::RestingOrder;
+pub use state::{ClaimedSeat, Market, MarketFixed, OrderIterator, RBNodeHeader, RestingOrder};
 
 // Event types
-pub use events::BaseAtoms;
-pub use events::GlobalAtoms;
-pub use events::PodBool;
-pub use events::QuoteAtoms;
-pub use events::QuoteAtomsPerBaseAtom;
+pub use events::{BaseAtoms, GlobalAtoms, PodBool, QuoteAtoms, QuoteAtomsPerBaseAtom};
 // Event discriminants
-pub use events::CANCEL_ORDER_LOG_DISCRIMINANT;
-pub use events::CLAIM_SEAT_LOG_DISCRIMINANT;
-pub use events::CREATE_MARKET_LOG_DISCRIMINANT;
-pub use events::DEPOSIT_LOG_DISCRIMINANT;
-pub use events::FILL_LOG_DISCRIMINANT;
-pub use events::GLOBAL_ADD_TRADER_LOG_DISCRIMINANT;
-pub use events::GLOBAL_CLAIM_SEAT_LOG_DISCRIMINANT;
-pub use events::GLOBAL_CLEANUP_LOG_DISCRIMINANT;
-pub use events::GLOBAL_CREATE_LOG_DISCRIMINANT;
-pub use events::GLOBAL_DEPOSIT_LOG_DISCRIMINANT;
-pub use events::GLOBAL_EVICT_LOG_DISCRIMINANT;
-pub use events::GLOBAL_WITHDRAW_LOG_DISCRIMINANT;
-pub use events::PLACE_ORDER_LOG_DISCRIMINANT;
-pub use events::PLACE_ORDER_LOG_V2_DISCRIMINANT;
-pub use events::WITHDRAW_LOG_DISCRIMINANT;
+pub use events::{
+    CANCEL_ORDER_LOG_DISCRIMINANT, CLAIM_SEAT_LOG_DISCRIMINANT, CREATE_MARKET_LOG_DISCRIMINANT,
+    DEPOSIT_LOG_DISCRIMINANT, FILL_LOG_DISCRIMINANT, GLOBAL_ADD_TRADER_LOG_DISCRIMINANT,
+    GLOBAL_CLAIM_SEAT_LOG_DISCRIMINANT, GLOBAL_CLEANUP_LOG_DISCRIMINANT,
+    GLOBAL_CREATE_LOG_DISCRIMINANT, GLOBAL_DEPOSIT_LOG_DISCRIMINANT, GLOBAL_EVICT_LOG_DISCRIMINANT,
+    GLOBAL_WITHDRAW_LOG_DISCRIMINANT, PLACE_ORDER_LOG_DISCRIMINANT,
+    PLACE_ORDER_LOG_V2_DISCRIMINANT, WITHDRAW_LOG_DISCRIMINANT,
+};
 // Event structs
-pub use events::CancelOrderLog;
-pub use events::ClaimSeatLog;
-pub use events::CreateMarketLog;
-pub use events::DepositLog;
-pub use events::FillLog;
-pub use events::GlobalAddTraderLog;
-pub use events::GlobalClaimSeatLog;
-pub use events::GlobalCleanupLog;
-pub use events::GlobalCreateLog;
-pub use events::GlobalDepositLog;
-pub use events::GlobalEvictLog;
-pub use events::GlobalWithdrawLog;
-pub use events::PlaceOrderLog;
-pub use events::PlaceOrderLogV2;
-pub use events::WithdrawLog;
+pub use events::{
+    CancelOrderLog, ClaimSeatLog, CreateMarketLog, DepositLog, FillLog, GlobalAddTraderLog,
+    GlobalClaimSeatLog, GlobalCleanupLog, GlobalCreateLog, GlobalDepositLog, GlobalEvictLog,
+    GlobalWithdrawLog, PlaceOrderLog, PlaceOrderLogV2, WithdrawLog,
+};
 
 #[cfg(test)]
 mod tests;

--- a/client/rust/slim/src/state.rs
+++ b/client/rust/slim/src/state.rs
@@ -1,14 +1,10 @@
 //! Market state parsing for Manifest.
 
-use crate::constants::OrderType;
-use crate::constants::CLAIMED_SEAT_SIZE;
-use crate::constants::MARKET_FIXED_DISCRIMINANT;
-use crate::constants::MARKET_FIXED_SIZE;
-use crate::constants::NO_EXPIRATION_LAST_VALID_SLOT;
-use crate::constants::RESTING_ORDER_SIZE;
-use hypertree::DataIndex;
-use hypertree::NIL;
-use hypertree::RBTREE_OVERHEAD_BYTES;
+use crate::constants::{
+    OrderType, CLAIMED_SEAT_SIZE, MARKET_FIXED_DISCRIMINANT, MARKET_FIXED_SIZE,
+    NO_EXPIRATION_LAST_VALID_SLOT, RESTING_ORDER_SIZE,
+};
+use hypertree::{DataIndex, NIL, RBTREE_OVERHEAD_BYTES};
 use solana_pubkey::Pubkey;
 
 /// The fixed header of a market account.

--- a/client/rust/slim/src/tests.rs
+++ b/client/rust/slim/src/tests.rs
@@ -5,25 +5,15 @@
 
 #[cfg(test)]
 mod integration_tests {
-    use crate::batch_update_instruction;
-    use crate::claim_seat_instruction;
-    use crate::create_market_instruction;
-    use crate::deposit_instruction;
-    use crate::swap_instruction;
-    use crate::withdraw_instruction;
-    use crate::BatchUpdateParams;
-    use crate::DepositParams;
-    use crate::Market;
-    use crate::PlaceOrderParams;
-    use crate::SwapParams;
-    use crate::WithdrawParams;
-    use crate::MARKET_FIXED_SIZE;
-    use crate::TOKEN_2022_PROGRAM_ID;
-    use crate::TOKEN_PROGRAM_ID;
+    use crate::{
+        batch_update_instruction, claim_seat_instruction, create_market_instruction,
+        deposit_instruction, swap_instruction, withdraw_instruction, BatchUpdateParams,
+        DepositParams, Market, PlaceOrderParams, SwapParams, WithdrawParams, MARKET_FIXED_SIZE,
+        TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID,
+    };
     use solana_pubkey::Pubkey;
 
-    use solana_program::program_pack::Pack;
-    use solana_program::system_instruction;
+    use solana_program::{program_pack::Pack, system_instruction};
     use solana_program_test::{processor, ProgramTest};
     use solana_sdk::{
         instruction::Instruction as SolanaInstruction,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Britt Cyr <britt@cks.systems>"]
 description = "Data structures for Manifest"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [features]
 colored = ["dep:colored"]
 fuzz = []

--- a/programs/manifest/Cargo.toml
+++ b/programs/manifest/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Britt Cyr <britt@manifest.trade>"]
 description = "Onchain orderbook optimized for space and accounts"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "manifest"

--- a/programs/manifest/src/state/claimed_seat.rs
+++ b/programs/manifest/src/state/claimed_seat.rs
@@ -87,5 +87,5 @@ impl std::fmt::Display for ClaimedSeat {
 #[test]
 fn test_display() {
     let claimed_seat: ClaimedSeat = ClaimedSeat::new_empty(Pubkey::default());
-    format!("{}", claimed_seat);
+    let _ = format!("{}", claimed_seat);
 }

--- a/programs/manifest/src/state/global.rs
+++ b/programs/manifest/src/state/global.rs
@@ -672,7 +672,7 @@ mod test {
 
     #[test]
     fn test_display_trader() {
-        format!("{}", GlobalTrader::default());
+        let _ = format!("{}", GlobalTrader::default());
     }
 
     #[test]
@@ -686,7 +686,7 @@ mod test {
 
     #[test]
     fn test_display_deposit() {
-        format!("{}", GlobalDeposit::default());
+        let _ = format!("{}", GlobalDeposit::default());
     }
 
     #[test]

--- a/programs/manifest/src/state/resting_order.rs
+++ b/programs/manifest/src/state/resting_order.rs
@@ -306,7 +306,7 @@ mod test {
             OrderType::Limit,
         )
         .unwrap();
-        format!("{}", resting_order);
+        let _ = format!("{}", resting_order);
     }
 
     #[test]

--- a/programs/manifest/tests/cases/create_market.rs
+++ b/programs/manifest/tests/cases/create_market.rs
@@ -36,7 +36,7 @@ async fn create_market_fail_same_base_and_quote() -> anyhow::Result<()> {
 async fn create_market_fail_already_initialized() -> anyhow::Result<()> {
     let test_fixture: TestFixture = TestFixture::new().await;
 
-    let mut context_cell: RefMut<ProgramTestContext> = test_fixture.context.borrow_mut();
+    let context_cell: RefMut<ProgramTestContext> = test_fixture.context.borrow_mut();
     let market_keypair: Keypair = Keypair::new();
     let payer: &Pubkey = &context_cell.payer.pubkey();
     let create_market_ixs: Vec<Instruction> = create_market_instructions(

--- a/programs/manifest/tests/cases/exploit_global_reduce.rs
+++ b/programs/manifest/tests/cases/exploit_global_reduce.rs
@@ -24,7 +24,7 @@ use manifest::{
 };
 use solana_program_test::ProgramTest;
 use solana_sdk::{
-    instruction::Instruction, program_pack::Pack, pubkey::Pubkey, rent::Rent, signature::Keypair,
+    program_pack::Pack, pubkey::Pubkey, rent::Rent, signature::Keypair,
     signer::Signer, system_instruction::create_account,
 };
 

--- a/programs/manifest/tests/cases/exploit_global_reduce.rs
+++ b/programs/manifest/tests/cases/exploit_global_reduce.rs
@@ -24,8 +24,8 @@ use manifest::{
 };
 use solana_program_test::ProgramTest;
 use solana_sdk::{
-    program_pack::Pack, pubkey::Pubkey, rent::Rent, signature::Keypair,
-    signer::Signer, system_instruction::create_account,
+    program_pack::Pack, pubkey::Pubkey, rent::Rent, signature::Keypair, signer::Signer,
+    system_instruction::create_account,
 };
 
 use crate::{manifest_program_test, send_tx_with_retry, MintFixture, RUST_LOG_DEFAULT};

--- a/programs/manifest/tests/cases/global.rs
+++ b/programs/manifest/tests/cases/global.rs
@@ -1640,17 +1640,6 @@ async fn global_create_with_dusted_address() -> anyhow::Result<()> {
     // Get the global PDA address that will be created for this mint
     let (global_key, _global_bump) = get_global_address(&mint_fixture.key);
 
-    // Get payer's initial balance
-    let payer_initial_balance: u64 = test_fixture
-        .context
-        .borrow_mut()
-        .banks_client
-        .get_account(payer)
-        .await
-        .unwrap()
-        .unwrap()
-        .lamports;
-
     // "Dust" the global address with SOL before it's initialized
     let dust_amount: u64 = 10_000_000; // 0.01 SOL
     send_tx_with_retry(
@@ -1869,7 +1858,7 @@ async fn global_match_multiple_levels_with_unbacked() -> anyhow::Result<()> {
 /// before creating the token account. Tests both regular SPL token and Token-2022.
 #[tokio::test]
 async fn global_create_with_dusted_vault_address() -> anyhow::Result<()> {
-    use manifest::validation::{get_global_address, get_global_vault_address};
+    use manifest::validation::get_global_vault_address;
     use solana_sdk::system_instruction::transfer;
 
     let test_fixture: TestFixture = TestFixture::new().await;

--- a/programs/manifest/tests/cases/swap.rs
+++ b/programs/manifest/tests/cases/swap.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::{RefCell, RefMut},
+    cell::RefMut,
     rc::Rc,
 };
 
@@ -7,9 +7,7 @@ use borsh::BorshSerialize;
 use manifest::{
     program::{
         batch_update::{CancelOrderParams, PlaceOrderParams},
-        batch_update_instruction,
-        claim_seat_instruction::claim_seat_instruction,
-        deposit_instruction, expand_market_instruction, global_add_trader_instruction,
+        batch_update_instruction, expand_market_instruction, global_add_trader_instruction,
         global_deposit_instruction, global_withdraw_instruction, swap_instruction,
         ManifestInstruction, SwapParams,
     },
@@ -17,18 +15,16 @@ use manifest::{
     state::{constants::NO_EXPIRATION_LAST_VALID_SLOT, OrderType, RestingOrder},
     validation::get_vault_address,
 };
-use solana_program_test::{tokio, ProgramTest, ProgramTestContext};
+use solana_program_test::{tokio, ProgramTestContext};
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
 };
 
 use crate::{
-    create_market_with_mints, create_spl_token_account, create_token_2022_account, expand_market,
-    manifest_program_test, mint_token_2022, send_tx_with_retry, MintFixture, Side, TestFixture,
-    Token, TokenAccountFixture, RUST_LOG_DEFAULT, SOL_UNIT_SIZE, USDC_UNIT_SIZE,
+    send_tx_with_retry, Side, TestFixture,
+    Token, TokenAccountFixture, SOL_UNIT_SIZE, USDC_UNIT_SIZE,
 };
 
 #[tokio::test]

--- a/programs/manifest/tests/cases/swap.rs
+++ b/programs/manifest/tests/cases/swap.rs
@@ -1,7 +1,4 @@
-use std::{
-    cell::RefMut,
-    rc::Rc,
-};
+use std::{cell::RefMut, rc::Rc};
 
 use borsh::BorshSerialize;
 use manifest::{
@@ -23,8 +20,8 @@ use solana_sdk::{
 };
 
 use crate::{
-    send_tx_with_retry, Side, TestFixture,
-    Token, TokenAccountFixture, SOL_UNIT_SIZE, USDC_UNIT_SIZE,
+    send_tx_with_retry, Side, TestFixture, Token, TokenAccountFixture, SOL_UNIT_SIZE,
+    USDC_UNIT_SIZE,
 };
 
 #[tokio::test]

--- a/programs/manifest/tests/program_test/fixtures.rs
+++ b/programs/manifest/tests/program_test/fixtures.rs
@@ -1575,7 +1575,7 @@ pub async fn get_and_deserialize<T: Pack>(
     context: Rc<RefCell<ProgramTestContext>>,
     pubkey: Pubkey,
 ) -> T {
-    let mut context: RefMut<ProgramTestContext> = context.borrow_mut();
+    let context: RefMut<ProgramTestContext> = context.borrow_mut();
     loop {
         let account_or: Result<Option<Account>, BanksClientError> =
             context.banks_client.get_account(pubkey).await;

--- a/programs/ui-wrapper/Cargo.toml
+++ b/programs/ui-wrapper/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Maximilian Schneider <max@mango.markets>"]
 description = "UI Wrapper for Manifest"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "ui_wrapper"

--- a/programs/ui-wrapper/src/market_info.rs
+++ b/programs/ui-wrapper/src/market_info.rs
@@ -93,7 +93,7 @@ impl std::fmt::Display for MarketInfo {
 #[test]
 fn test_display() {
     let market_info: MarketInfo = MarketInfo::new_empty(Pubkey::default(), 0);
-    format!("{}", market_info);
+    let _ = format!("{}", market_info);
 }
 
 #[test]

--- a/programs/ui-wrapper/src/open_order.rs
+++ b/programs/ui-wrapper/src/open_order.rs
@@ -158,7 +158,7 @@ fn test_display() {
         false,
         OrderType::Limit,
     );
-    format!("{}", open_order);
+    let _ = format!("{}", open_order);
 }
 
 #[test]

--- a/programs/ui-wrapper/tests/program_test/fixtures.rs
+++ b/programs/ui-wrapper/tests/program_test/fixtures.rs
@@ -946,7 +946,7 @@ pub async fn get_and_deserialize<T: Pack>(
     context: Rc<RefCell<ProgramTestContext>>,
     pubkey: Pubkey,
 ) -> T {
-    let mut context: RefMut<ProgramTestContext> = context.borrow_mut();
+    let context: RefMut<ProgramTestContext> = context.borrow_mut();
     loop {
         let account_or: Result<Option<Account>, BanksClientError> =
             context.banks_client.get_account(pubkey).await;

--- a/programs/wrapper/Cargo.toml
+++ b/programs/wrapper/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Britt Cyr <britt@cks.systems>"]
 description = "Wrapper for Manifest"
 license-file = "LICENSE"
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib", "lib"]
 name = "wrapper"

--- a/programs/wrapper/src/market_info.rs
+++ b/programs/wrapper/src/market_info.rs
@@ -89,7 +89,7 @@ impl std::fmt::Display for MarketInfo {
 #[test]
 fn test_display() {
     let market_info: MarketInfo = MarketInfo::new_empty(Pubkey::default(), 0);
-    format!("{}", market_info);
+    let _ = format!("{}", market_info);
 }
 
 #[test]

--- a/programs/wrapper/src/open_order.rs
+++ b/programs/wrapper/src/open_order.rs
@@ -145,7 +145,7 @@ fn test_display() {
         false,
         OrderType::Limit,
     );
-    format!("{}", open_order);
+    let _ = format!("{}", open_order);
 }
 
 #[test]


### PR DESCRIPTION
- Add check-cfg configuration to workspace Cargo.toml for Solana-specific cfgs
- Add [lints] workspace = true to all workspace members
- Fix unused imports via cargo fix
- Fix unused mut variable (prefix with underscore)
- Fix unused return values from format! in Display tests