### PR TITLE
Optimize completeFills database queries

### DIFF
--- a/scripts/stats_utils/constants.ts
+++ b/scripts/stats_utils/constants.ts
@@ -6,6 +6,8 @@ export const VOLUME_CHECKPOINT_DURATION_SEC: number = 5 * 60;
 export const DATABASE_CHECKPOINT_DURATION_SEC: number = 60 * 60;
 export const ONE_HOUR_SEC: number = 60 * 60;
 export const ONE_DAY_SEC: number = 24 * ONE_HOUR_SEC;
+// Solana slot time is ~400ms, so ~2.5 slots/sec = ~216,000 slots/day
+export const SLOTS_PER_DAY: number = 216_000;
 export const PORT: number = 3000;
 export const DEPTHS_BPS: number[] = [50, 100, 200];
 

--- a/scripts/stats_utils/manifestStatsServer.ts
+++ b/scripts/stats_utils/manifestStatsServer.ts
@@ -20,6 +20,7 @@ import { Pool, PoolClient, QueryResult } from 'pg';
 import {
   VOLUME_CHECKPOINT_DURATION_SEC,
   ONE_DAY_SEC,
+  SLOTS_PER_DAY,
   DEPTHS_BPS,
   SOL_USDC_MARKET,
   CBBTC_USDC_MARKET,
@@ -1687,9 +1688,19 @@ export class ManifestStatsServer {
       signature,
       limit = 100,
       offset = 0,
-      fromSlot,
       toSlot,
     } = options;
+
+    // Apply default slot filter only if no efficient index filter is present
+    const hasEfficientFilter = market || signature || taker || maker;
+    let { fromSlot } = options;
+    if (fromSlot === undefined && !hasEfficientFilter) {
+      console.log(
+        `[completeFills] Query without efficient filter, applying default slot range. Options: ${JSON.stringify(options)}`,
+      );
+      const currentSlot = await this.connection.getSlot();
+      fromSlot = currentSlot - SLOTS_PER_DAY;
+    }
 
     try {
       const conditions: string[] = [];
@@ -1751,7 +1762,7 @@ export class ManifestStatsServer {
       const dataQuery = `
       ${queries.SELECT_FILLS_COMPLETE_DATA_BASE}
       ${whereClause}
-      ORDER BY slot DESC, timestamp DESC
+      ORDER BY timestamp DESC
       LIMIT $${paramIndex++} OFFSET $${paramIndex++}
     `;
 


### PR DESCRIPTION
- Add default slot filter for queries without efficient index filters (market, signature, taker, maker). Defaults to last day of slots to prevent unbounded table scans when only wallet filter or no filter is provided.
- Change ORDER BY from "slot DESC, timestamp DESC" to "timestamp DESC" to match the existing idx_fills_complete_market_timestamp index, avoiding expensive sorts