### PR TITLE
Fail trade verification on install errors

### DIFF
--- a/.github/workflows/ci-trade-verification.yml
+++ b/.github/workflows/ci-trade-verification.yml
@@ -19,12 +19,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: |
-          echo "Installing dependencies..."
-          yarn install --frozen-lockfile || {
-            echo "Warning: Dependency installation failed, continuing..."
-            exit 0
-          }
+        run: yarn install --frozen-lockfile
 
       - name: Run the trade verification
         run: npx tsx scripts/verify-trades.ts


### PR DESCRIPTION
## Summary

Remove the fail-open dependency install block from the Trade Verification workflow.

## Why

The workflow had originally been created as informational-only, so dependency install failures were downgraded to a warning. The verifier later became a failing check for trade mismatches, but the install step still hid dependency failures. That made a broken install look less serious than it is for scheduled monitoring.

## Impact

If `yarn install --frozen-lockfile` fails, the workflow now fails immediately instead of continuing with a missing or partial dependency tree.

## Validation

- `git diff --check`
- `ASDF_NODEJS_VERSION=24.13.1 yarn install --frozen-lockfile`
- Ruby YAML parse of `.github/workflows/ci-trade-verification.yml`