### PR TITLE
Defer global gas prepayment refunds to avoid UnbalancedInstruction

### DIFF
--- a/client/rust/jup/src/lib.rs
+++ b/client/rust/jup/src/lib.rs
@@ -191,6 +191,7 @@ impl Amm for ManifestMarket {
                     gas_payer_opt: None,
                     gas_receiver_opt: None,
                     market: self.key.clone(),
+                    num_deferred_gas_refunds: std::cell::Cell::new(0),
                 })
             } else {
                 None
@@ -216,6 +217,7 @@ impl Amm for ManifestMarket {
                     gas_payer_opt: None,
                     gas_receiver_opt: None,
                     market: self.key.clone(),
+                    num_deferred_gas_refunds: std::cell::Cell::new(0),
                 })
             } else {
                 None
@@ -468,6 +470,7 @@ mod test {
                 gas_payer_opt: Some(gas_payer_account_info),
                 gas_receiver_opt: None,
                 market: MARKET_KEY,
+                num_deferred_gas_refunds: std::cell::Cell::new(0),
             });
 
         dynamic_value_to_account!(

--- a/programs/manifest/src/program/processor/batch_update.rs
+++ b/programs/manifest/src/program/processor/batch_update.rs
@@ -6,7 +6,7 @@ use crate::{
     quantities::{BaseAtoms, PriceConversionError, QuoteAtomsPerBaseAtom, WrapperU64},
     require,
     state::{
-        utils::{get_now_slot, try_to_pay_all_global_gas_prepayment},
+        utils::{get_now_slot, settle_global_gas_refunds, try_to_pay_all_global_gas_prepayment},
         AddOrderToMarketArgs, AddOrderToMarketResult, MarketRefMut, OrderType, RestingOrder,
         MARKET_BLOCK_SIZE,
     },
@@ -362,6 +362,14 @@ pub(crate) fn process_batch_update_core(
             result.push((order_sequence_number, order_index));
         }
         expand_market_if_needed(&payer, &market)?;
+    }
+
+    // Pay out gas prepayment refunds for cancelled global orders. This must
+    // happen after the last CPI of this instruction (gas prepayments and
+    // market expansions above) because it moves lamports directly.
+    #[cfg(not(feature = "certora"))]
+    {
+        settle_global_gas_refunds(&global_trade_accounts_opts)?;
     }
 
     // Formal verification does not cover return values.

--- a/programs/manifest/src/program/processor/global_clean.rs
+++ b/programs/manifest/src/program/processor/global_clean.rs
@@ -8,7 +8,10 @@ use crate::{
     program::{batch_update::MarketDataTreeNodeType, get_mut_dynamic_account},
     quantities::{GlobalAtoms, WrapperU64},
     require,
-    state::{utils::get_now_slot, GlobalRefMut, MarketRefMut, RestingOrder, MARKET_BLOCK_SIZE},
+    state::{
+        utils::{get_now_slot, settle_global_gas_refunds},
+        GlobalRefMut, MarketRefMut, RestingOrder, MARKET_BLOCK_SIZE,
+    },
     validation::loaders::{GlobalCleanContext, GlobalTradeAccounts},
 };
 
@@ -48,6 +51,7 @@ pub(crate) fn process_global_clean(
         market: *market.key,
         gas_payer_opt: None,
         gas_receiver_opt: Some(payer),
+        num_deferred_gas_refunds: std::cell::Cell::new(0),
     };
 
     let GlobalCleanParams { order_index } = GlobalCleanParams::try_from_slice(data)?;
@@ -137,6 +141,9 @@ pub(crate) fn process_global_clean(
     // The global account itself only accounting on remove_order is that it
     // tracks unclaimed gas deposits for informational purposes and this is
     // claiming anyways.
+
+    // Pay the gas prepayment refund to the cleaner.
+    settle_global_gas_refunds(&global_trade_accounts)?;
 
     Ok(())
 }

--- a/programs/manifest/src/state/utils.rs
+++ b/programs/manifest/src/state/utils.rs
@@ -73,47 +73,54 @@ pub(crate) fn remove_from_global(
         return Ok(());
     }
     let global_trade_accounts: &GlobalTradeAccounts = &global_trade_accounts_opt.as_ref().unwrap();
-    let GlobalTradeAccounts {
-        global,
-        gas_receiver_opt,
-        ..
-    } = global_trade_accounts;
 
-    // The simple implementation gets
-    //
-    //     **receiver.lamports.borrow_mut() += GAS_DEPOSIT_LAMPORTS;
-    //     **global.lamports.borrow_mut() -= GAS_DEPOSIT_LAMPORTS;
+    // The refund cannot be a CPI because the global account carries data
+    // (`from` must not carry data), so it has to be a direct lamport
+    // manipulation. Direct lamport manipulation is only synced back to the
+    // runtime for accounts included in a later CPI, so if we moved the
+    // lamports here and a later CPI in the same instruction included only one
+    // of the two accounts (e.g. the gas prepayment transfer for the other
+    // side's global, or a market expand), the runtime lamport sum check fails
+    // with
     //
     // failed: sum of account balances before and after instruction do not match
     //
-    // doesnt make sense, but thats the solana runtime.
-    //
-    // Done here instead of inside the object because the borrow checker needs
-    // to get the data on global which it cannot while there is a mut self
-    // reference. Note that if it isnt claimed here, then nobody does and it is
-    // lost to the global account.
-    //
-    // Then we tried to do a CPI, but that fails because
-    //
-    // `from` must not carry data
-    //
-    // if let Some(system_program) = &global_trade_accounts.system_program {
-    //     solana_program::program::invoke_signed(
-    //         &solana_program::system_instruction::transfer(
-    //             &global.key,
-    //             &trader.info.key,
-    //             GAS_DEPOSIT_LAMPORTS,
-    //         ),
-    //         &[global.info.clone(), trader.info.clone(), system_program.info.clone()],
-    //         global_seeds_with_bump!(mint, global_bump),
-    //     )?;
-    // }
-    //
-    // Somehow, a hybrid works. Dont know why, but it does.
-    //
+    // Instead, just count the refund here and move the lamports in
+    // settle_global_gas_refunds after the last CPI of the instruction.
     if global_trade_accounts.system_program.is_some() {
-        **global.lamports.borrow_mut() -= GAS_DEPOSIT_LAMPORTS;
-        **gas_receiver_opt.as_ref().unwrap().lamports.borrow_mut() += GAS_DEPOSIT_LAMPORTS;
+        let num_deferred_gas_refunds: &std::cell::Cell<u64> =
+            &global_trade_accounts.num_deferred_gas_refunds;
+        num_deferred_gas_refunds.set(num_deferred_gas_refunds.get().checked_add(1).unwrap());
+    }
+
+    Ok(())
+}
+
+/// Pays out the gas prepayment refunds accumulated by remove_from_global.
+/// Must be called after the last CPI in the instruction because the direct
+/// lamport manipulation is not synced into a later CPI unless that CPI
+/// includes both accounts, which would fail the runtime lamport sum check.
+pub(crate) fn settle_global_gas_refunds(
+    global_trade_accounts_opts: &[Option<GlobalTradeAccounts>; 2],
+) -> ProgramResult {
+    for global_trade_accounts_opt in global_trade_accounts_opts.iter() {
+        if global_trade_accounts_opt.is_none() {
+            continue;
+        }
+        let global_trade_accounts: &GlobalTradeAccounts =
+            global_trade_accounts_opt.as_ref().unwrap();
+        let num_refunds: u64 = global_trade_accounts.num_deferred_gas_refunds.take();
+        if num_refunds == 0 {
+            continue;
+        }
+        let GlobalTradeAccounts {
+            global,
+            gas_receiver_opt,
+            ..
+        } = global_trade_accounts;
+        let refund_lamports: u64 = GAS_DEPOSIT_LAMPORTS.checked_mul(num_refunds).unwrap();
+        **global.lamports.borrow_mut() -= refund_lamports;
+        **gas_receiver_opt.as_ref().unwrap().lamports.borrow_mut() += refund_lamports;
     }
 
     Ok(())

--- a/programs/manifest/src/state/utils.rs
+++ b/programs/manifest/src/state/utils.rs
@@ -118,6 +118,40 @@ pub(crate) fn settle_global_gas_refunds(
             gas_receiver_opt,
             ..
         } = global_trade_accounts;
+
+        // The simple implementation gets
+        //
+        //     **receiver.lamports.borrow_mut() += GAS_DEPOSIT_LAMPORTS;
+        //     **global.lamports.borrow_mut() -= GAS_DEPOSIT_LAMPORTS;
+        //
+        // failed: sum of account balances before and after instruction do not match
+        //
+        // when a CPI that includes only one of the two accounts follows in the
+        // same instruction, because the runtime re-checks the lamport sum at
+        // every CPI boundary and only syncs direct lamport manipulation for
+        // accounts passed into the CPI. Thats why this is deferred until after
+        // the last CPI of the instruction.
+        //
+        // Done here instead of inside the object because the borrow checker
+        // needs to get the data on global which it cannot while there is a mut
+        // self reference. Note that if it isnt claimed here, then nobody does
+        // and it is lost to the global account.
+        //
+        // We also tried to do a CPI, but that fails because
+        //
+        // `from` must not carry data
+        //
+        // if let Some(system_program) = &global_trade_accounts.system_program {
+        //     solana_program::program::invoke_signed(
+        //         &solana_program::system_instruction::transfer(
+        //             &global.key,
+        //             &trader.info.key,
+        //             GAS_DEPOSIT_LAMPORTS,
+        //         ),
+        //         &[global.info.clone(), trader.info.clone(), system_program.info.clone()],
+        //         global_seeds_with_bump!(mint, global_bump),
+        //     )?;
+        // }
         let refund_lamports: u64 = GAS_DEPOSIT_LAMPORTS.checked_mul(num_refunds).unwrap();
         **global.lamports.borrow_mut() -= refund_lamports;
         **gas_receiver_opt.as_ref().unwrap().lamports.borrow_mut() += refund_lamports;

--- a/programs/manifest/src/validation/loaders.rs
+++ b/programs/manifest/src/validation/loaders.rs
@@ -1,4 +1,7 @@
-use std::{cell::Ref, slice::Iter};
+use std::{
+    cell::{Cell, Ref},
+    slice::Iter,
+};
 
 use hypertree::{get_helper, trace};
 use solana_program::{
@@ -443,6 +446,7 @@ impl<'a, 'info> SwapContext<'a, 'info> {
                     },
                     market: *market.info.key,
                     system_program: None,
+                    num_deferred_gas_refunds: Cell::new(0),
                 });
             }
         }
@@ -484,6 +488,15 @@ pub struct GlobalTradeAccounts<'a, 'info> {
     pub gas_payer_opt: Option<Signer<'a, 'info>>,
     pub gas_receiver_opt: Option<Signer<'a, 'info>>,
     pub market: Pubkey,
+
+    // Number of gas prepayment refunds owed to the gas receiver for removed
+    // global orders. Refunds are accumulated here and the lamports are only
+    // moved at the end of the instruction (settle_global_gas_refunds) because
+    // moving them directly before a later CPI that includes only one of the
+    // two accounts makes the runtime lamport sum check fail with
+    // UnbalancedInstruction. Processors that pass a system_program must settle
+    // before returning or the refunds are stranded on the global account.
+    pub num_deferred_gas_refunds: Cell<u64>,
 }
 
 /// BatchUpdate account infos
@@ -599,6 +612,7 @@ impl<'a, 'info> BatchUpdateContext<'a, 'info> {
                         gas_payer_opt: Some(payer.clone()),
                         gas_receiver_opt: Some(payer.clone()),
                         market: *market.info.key,
+                        num_deferred_gas_refunds: Cell::new(0),
                     })
                 };
             }

--- a/programs/manifest/tests/cases/global.rs
+++ b/programs/manifest/tests/cases/global.rs
@@ -2093,3 +2093,123 @@ async fn global_evict_fails_with_transfer_fee() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// Regression test: cancelling a global order on one side while placing a
+// global order on the other side in the same batch update used to fail with
+// "sum of account balances before and after instruction do not match". The
+// cancel refunded the gas prepayment with a direct lamport move from the base
+// global account, and the gas prepayment CPI for the new bid only included
+// the quote global account, so the runtime lamport sum check at the CPI
+// boundary saw the payer credit without the base global debit.
+#[tokio::test]
+async fn global_cancel_and_place_opposite_sides() -> anyhow::Result<()> {
+    let mut test_fixture: TestFixture = TestFixture::new().await;
+    test_fixture.claim_seat().await?;
+    let payer: Pubkey = test_fixture.payer();
+    let payer_keypair: Keypair = test_fixture.payer_keypair().insecure_clone();
+
+    // Quote (USDC) global to back the bid.
+    test_fixture.global_add_trader().await?;
+    test_fixture.global_deposit(1_000_000).await?;
+
+    // Base (SOL) global to back the ask.
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[global_add_trader_instruction(
+            &test_fixture.sol_global_fixture.key,
+            &payer,
+        )],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+    let token_account_keypair: Keypair = Keypair::new();
+    let token_account_fixture: TokenAccountFixture = TokenAccountFixture::new_with_keypair(
+        Rc::clone(&test_fixture.context),
+        &test_fixture.sol_global_fixture.mint_key,
+        &payer,
+        &token_account_keypair,
+    )
+    .await;
+    test_fixture
+        .sol_mint_fixture
+        .mint_to(&token_account_fixture.key, 1_000_000)
+        .await;
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[global_deposit_instruction(
+            &test_fixture.sol_global_fixture.mint_key,
+            &payer,
+            &token_account_fixture.key,
+            &spl_token::id(),
+            1_000_000,
+        )],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    let base_mint: Pubkey = *test_fixture.market_fixture.market.get_base_mint();
+    let quote_mint: Pubkey = *test_fixture.market_fixture.market.get_quote_mint();
+
+    // Place a global ask.
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[batch_update_instruction(
+            &test_fixture.market_fixture.key,
+            &payer,
+            None,
+            vec![],
+            vec![PlaceOrderParams::new(
+                10,
+                2,
+                0,
+                false,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            Some(base_mint),
+            None,
+            Some(quote_mint),
+            None,
+        )],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    // Cancel the global ask and place a global bid in the same instruction.
+    // The refund comes from the base global account while the gas prepayment
+    // CPI only includes the quote global account.
+    send_tx_with_retry(
+        Rc::clone(&test_fixture.context),
+        &[batch_update_instruction(
+            &test_fixture.market_fixture.key,
+            &payer,
+            None,
+            vec![CancelOrderParams::new(0)],
+            vec![PlaceOrderParams::new(
+                10,
+                1,
+                0,
+                true,
+                OrderType::Global,
+                NO_EXPIRATION_LAST_VALID_SLOT,
+            )],
+            Some(base_mint),
+            None,
+            Some(quote_mint),
+            None,
+        )],
+        Some(&payer),
+        &[&payer_keypair],
+    )
+    .await?;
+
+    test_fixture.market_fixture.reload().await;
+    let orders: Vec<RestingOrder> = test_fixture.market_fixture.get_resting_orders().await;
+    assert_eq!(orders.len(), 1, "Expected only the new bid to be resting");
+    assert!(orders.get(0).unwrap().get_is_bid(), "Expected a bid");
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Batch updates that cancel global orders and place global orders on the opposite side in the same transaction fail with:

```
Program MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms failed: sum of account balances before and after instruction do not match
```

Seen in production on USDS/USDC when refreshing stable-pair quotes (cancelAll of global asks + placement of global bids in one tx).

## Root cause

The refund amounts were always correct — the bug is in *how* the refund moves lamports. `remove_from_global` refunds the 5,000-lamport gas prepayment with a direct lamport write (`global -= / payer +=`), since a System CPI is impossible (`from` must not carry data). The runtime only syncs direct lamport writes into its own bookkeeping for accounts included in a later CPI, and it re-checks the caller's lamport sum at every CPI boundary.

So when a batch update:
1. cancels a global **ask** → direct write debits the **base** global, credits the payer, then
2. places a global **bid** → gas prepayment CPI includes only the payer and the **quote** global,

the CPI boundary check sees the payer credit without the base global debit and fails the instruction. The same failure mode existed for a global cancel followed by a market-expansion transfer. Single-sided cancel+place never hit this because the refund and the payment CPI touch the same global account, so both ends of the direct write get synced.

## Fix

Accumulate refunds in a counter on `GlobalTradeAccounts` (`num_deferred_gas_refunds`) instead of moving lamports immediately, and settle them with a single direct write per side in `settle_global_gas_refunds` at the end of the instruction, after the last possible CPI (gas prepayments, market expansions). Applied to `batch_update` and `global_clean`; swap paths pass no system program and forfeit refunds, unchanged.

Net lamport flows are identical to before — only the point within the instruction where the refund lamports move changes. One minor behavioral note: the payer now needs to front the prepayment for new global orders before receiving cancel refunds within the same instruction (5,000 lamports per order).

## Testing

- New regression test `global_cancel_and_place_opposite_sides` reproduces the exact production failure without the fix and passes with it.
- Full `manifest-dex` suite: 117 passed. Wrapper suite: 9 passed. Clippy and rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)