### PR TITLE
Harden off-chain services and clients against audit findings

### DIFF
--- a/audits/codex-cli-full-repo-findings-2026-07-29.json
+++ b/audits/codex-cli-full-repo-findings-2026-07-29.json
@@ -1,0 +1,3802 @@
+{
+  "documentType": "codex-security.findings",
+  "findings": [
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "forged Manifest fill records delivered to downstream consumers",
+          "sink": "WebSocket broadcast of a discriminator-matching decoded fill",
+          "source": "permissionless transaction account keys and log messages",
+          "summary": "A permissionless Solana user submits a transaction that merely includes the Manifest program key while an attacker-controlled program emits bytes with the public FillLog discriminator; the block feed scans every Program data line without invocation ownership and broadcasts the forged record. A short matching payload can also abort processing for that slot."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "The public, low-friction spoof path can corrupt shared fill data or disrupt block processing, but the demonstrated consequence is off-chain feed integrity rather than direct on-chain asset loss. Medium impact and high likelihood map mechanically to medium severity."
+        },
+        "likelihood": {
+          "level": "high",
+          "why": "The public, low-friction spoof path can corrupt shared fill data or disrupt block processing, but the demonstrated consequence is off-chain feed integrity rather than direct on-chain asset loss. Medium impact and high likelihood map mechanically to medium severity."
+        },
+        "limitations": [
+          "Consumers could independently verify transactions, and no repository evidence proves they execute asset transfers from a feed record. That limits impact but does not defeat the feed-authenticity boundary because the implementation itself presents and broadcasts the data as Manifest fills."
+        ],
+        "reachability": {
+          "attacker": "any Solana transaction submitter able to invoke an attacker-controlled program",
+          "entrypoint": "the finalized-block fill-feed processor",
+          "outcome": "forged Manifest fill records delivered to downstream consumers",
+          "preconditions": "The attacker mentions the Manifest key and emits a public discriminator-matching payload; a consumer trusts the feed without independent transaction verification.",
+          "summary": "Product surface: the block-based fill-feed service and its WebSocket consumers. Attacker: any public Solana transaction submitter who controls a program invocation. Boundary: logs from an unrelated program are accepted as authenticated Manifest fills and cross into downstream off-chain data consumers; no direct on-chain balance mutation follows from the parser."
+        },
+        "summary": "A permissionless Solana user submits a transaction that merely includes the Manifest program key while an attacker-controlled program emits bytes with the public FillLog discriminator; the block feed scans every Program data line without invocation ownership and broadcasts the forged record. A short matching payload can also abort processing for that slot."
+      },
+      "codeEvidence": [
+        {
+          "code": "  private transactionInvolvesManifestProgram(tx: any): boolean {\n    if (!tx.transaction?.message) {\n      return false;\n    }\n\n    const message = tx.transaction.message;\n    const programId = PROGRAM_ID.toBase58();\n\n    // Check legacy transaction format\n    if ('accountKeys' in message) {\n      const inAccountKeys = message.accountKeys.some(\n        (key: any) => key.toBase58() === programId,\n      );\n      if (inAccountKeys) {\n        return true;\n      }\n    }",
+          "endLine": 199,
+          "explanation": "The filter returns true when Manifest appears anywhere in the account keys, without proving an instruction invoked it.",
+          "id": "e1",
+          "label": "Account-key presence is treated as program involvement",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "root_control",
+          "startLine": 183
+        },
+        {
+          "code": "    const programDatas: string[] = messages.filter((message) => {\n      return message.includes('Program data:');\n    });\n\n    if (programDatas.length === 0 && !truncated) {\n      console.log('No program datas');\n      return;\n    }\n\n    const parsedFills: FillLogResult[] = [];\n    for (const programDataEntry of programDatas) {\n      const programData = programDataEntry.split(' ')[2];\n      const byteArray: Uint8Array = Uint8Array.from(atob(programData), (c) =>\n        c.charCodeAt(0),\n      );\n      const buffer = Buffer.from(byteArray);\n      if (!buffer.subarray(0, 8).equals(fillDiscriminant)) {\n        continue;\n      }",
+          "endLine": 323,
+          "explanation": "The parser filters all log lines by text and authenticates only the public fill discriminator.",
+          "id": "e2",
+          "label": "Every Program data line is scanned without emitter state",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "propagation",
+          "startLine": 305
+        },
+        {
+          "code": "      const deserializedFillLog: FillLog = FillLog.deserialize(\n        buffer.subarray(8),\n      )[0];\n      const fillResult = toFillLogResult(\n        deserializedFillLog,\n        slot,\n        signature,\n        originalSigner,\n        aggregator,\n        originatingProtocol,\n        signers,\n        blockTime ?? undefined,\n      );\n      const resultString: string = JSON.stringify(fillResult);\n      console.log('Got a fill', resultString);\n      parsedFills.push(fillResult);\n      fills.inc({\n        market: deserializedFillLog.market.toString(),\n        isGlobal: deserializedFillLog.isMakerGlobal.toString(),\n        takerIsBuy: deserializedFillLog.takerIsBuy.toString(),\n      });\n\n      // Send to all connected clients\n      this.wsManager.broadcast(JSON.stringify(fillResult));",
+          "endLine": 347,
+          "explanation": "A matching payload is deserialized, labeled as a fill, and broadcast to every connected consumer.",
+          "id": "e3",
+          "label": "Decoded data is broadcast as a Manifest fill",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "sink",
+          "startLine": 324
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "An attacker can mention Manifest as an unused account, emit discriminator-matching Program data from a different program, and have the block feed accept and broadcast it because the parser never binds each log to the emitting invocation."
+      },
+      "extensions": {
+        "candidateId": "candidate-ccca642d5b69ccb1",
+        "ledgerRowId": "candidate-ccca642d5b69ccb1"
+      },
+      "findingId": "csf_33fd7e93b967d30f1ffa0600",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:e001d4746230fe203d68575f95fc90e491388f26145f2695f427b0127c3a0d37"
+      },
+      "identity": {
+        "anchor": "block-fill-feed-log-provenance",
+        "instance": "block-fill-log-provenance"
+      },
+      "locations": [
+        {
+          "endLine": 321,
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "root_control",
+          "startLine": 305
+        },
+        {
+          "endLine": 236,
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "source",
+          "startLine": 183
+        },
+        {
+          "endLine": 347,
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "sink",
+          "startLine": 324
+        }
+      ],
+      "occurrenceId": "occ_15c158464e197e6b0dabff30",
+      "preventiveControls": [
+        "Use one provenance-aware Solana log parser for every fill-feed implementation.",
+        "Require downstream feed schemas to carry and verify transaction, instruction, and emitting-program identity."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Track Solana `Program <id> invoke`, success, and failure stack transitions while scanning logs, and decode `Program data:` only when the active frame is the Manifest program; reject malformed/truncated payloads per entry without aborting the slot.",
+      "remediationTests": [
+        "Process a transaction that lists Manifest only as an unused account while another program emits a valid-looking fill payload and assert no fill is broadcast.",
+        "Process nested CPI logs containing attacker and Manifest emissions and assert only data emitted in the Manifest frame is accepted."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "A fill record must be accepted only when its `Program data:` line was emitted by the Manifest invocation that the feed intends to authenticate. The implementation violates that invariant along this validated path: A permissionless Solana user submits a transaction that merely includes the Manifest program key while an attacker-controlled program emits bytes with the public FillLog discriminator; the block feed scans every Program data line without invocation ownership and broadcasts the forged record. A short matching payload can also abort processing for that slot."
+      },
+      "ruleId": "improper-input-validation.fill-log-emitter",
+      "severity": {
+        "changeConditions": "Raise impact only if a repository-backed consumer is shown to make irreversible financial or authorization decisions from unverified feed records; lower likelihood if emitter-stack binding is added.",
+        "level": "medium",
+        "rationale": "The public, low-friction spoof path can corrupt shared fill data or disrupt block processing, but the demonstrated consequence is off-chain feed integrity rather than direct on-chain asset loss. Medium impact and high likelihood map mechanically to medium severity."
+      },
+      "summary": "The block fill feed considers mere account-key presence proof that Manifest ran and then accepts `Program data:` emitted by unrelated programs. The affected boundary is the finalized-block fill-feed processor; the evidenced outcome is forged Manifest fill records delivered to downstream consumers.",
+      "taxonomy": {
+        "category": "Fill-log origin spoofing",
+        "cwe": [
+          "CWE-20",
+          "CWE-345"
+        ]
+      },
+      "title": "The block fill feed considers mere account-key presence proof that Manifest ran and then accepts `Program data:` emitted by unrelated programs",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: a permissionless transaction controls account keys and attacker-program logs",
+          "Exact source-control-sink path: key-presence filtering precedes an emitter-agnostic Program data scan",
+          "Realistic interface/boundary: finalized block RPC and the feed broadcast are concrete public boundaries",
+          "Security impact beyond self-only correctness: fabricated fills corrupt downstream feed integrity and malformed data can skip a block slot",
+          "Countercontrols/proof gaps: the public discriminator is not an authenticity control"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "No live transaction was submitted because static Solana log semantics and the missing emitter binding establish the spoof path.",
+          "Downstream harm depends on consumers treating the broadcast feed as authenticated, which the feed's fill-record purpose supports."
+        ],
+        "method": "bounded static transaction/log provenance trace",
+        "observations": [
+          "client/ts/src/fillFeedBlockSub.ts:183-236 treats Manifest key presence anywhere as involvement.",
+          "client/ts/src/fillFeedBlockSub.ts:305-347 scans every Program data line and authenticates only the public FillLog discriminator.",
+          "The transaction log stream contains nested invocations, but this parser does not track invoke/success stack ownership."
+        ],
+        "summary": "An attacker can mention Manifest as an unused account, emit discriminator-matching Program data from a different program, and have the block feed accept and broadcast it because the parser never binds each log to the emitting invocation."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "forged Manifest fill records delivered to signature-feed consumers",
+          "sink": "signature-feed WebSocket broadcast of decoded `Program data:`",
+          "source": "permissionless transactions returned for the Manifest address",
+          "summary": "A permissionless Solana user submits a transaction mentioning Manifest while an attacker-controlled program emits a discriminator-valid or deliberately short FillLog payload; getSignaturesForAddress returns the transaction, the signature feed scans all Program data lines without emitter binding, and it broadcasts forged data or exits parseLogs on deserialization failure."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "Forging or terminating the shared feed is permissionless and practical, while the established harm remains false off-chain fill data and service disruption. Medium impact and high likelihood map to medium severity."
+        },
+        "likelihood": {
+          "level": "high",
+          "why": "Forging or terminating the shared feed is permissionless and practical, while the established harm remains false off-chain fill data and service disruption. Medium impact and high likelihood map to medium severity."
+        },
+        "limitations": [
+          "Downstream consumers may independently reconcile fills, and the repository does not show an automatic asset transfer based solely on a feed message. That constrains impact but does not remove the directly reachable authentication failure in the feed."
+        ],
+        "reachability": {
+          "attacker": "any Solana transaction submitter able to mention Manifest and invoke an attacker program",
+          "entrypoint": "the signature-history fill-feed processor",
+          "outcome": "forged Manifest fill records delivered to signature-feed consumers",
+          "preconditions": "A transaction is returned by `getSignaturesForAddress()` and an unrelated invocation emits a discriminator-matching payload.",
+          "summary": "Product surface: the deployed-style signature-based fill feed and its WebSocket consumers. Attacker: any public Solana transaction submitter who controls a program invocation. Boundary: unrelated-program logs cross the provenance boundary and become purported Manifest fills; the proven effects are off-chain integrity and feed availability, not direct protocol asset movement."
+        },
+        "summary": "A permissionless Solana user submits a transaction mentioning Manifest while an attacker-controlled program emits a discriminator-valid or deliberately short FillLog payload; getSignaturesForAddress returns the transaction, the signature feed scans all Program data lines without emitter binding, and it broadcasts forged data or exits parseLogs on deserialization failure."
+      },
+      "codeEvidence": [
+        {
+          "code": "        const signatures: ConfirmedSignatureInfo[] =\n          await this.connection.getSignaturesForAddress(\n            PROGRAM_ID,\n            lastSignature ? { until: lastSignature } : undefined,\n            'finalized',",
+          "endLine": 125,
+          "explanation": "`getSignaturesForAddress(PROGRAM_ID)` returns transactions that mention the address; it does not bind later logs to their emitter.",
+          "id": "e1",
+          "label": "Signatures are selected by address mention",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "user_input",
+          "startLine": 121
+        },
+        {
+          "code": "    const programDatas: string[] = messages.filter((message) => {\n      return message.includes('Program data:');\n    });\n\n    if (programDatas.length == 0 && !truncated) {\n      console.log('No program datas');\n      return;\n    }\n\n    const parsedFills: FillLogResult[] = [];\n    for (const programDataEntry of programDatas) {\n      const programData = programDataEntry.split(' ')[2];\n      const byteArray: Uint8Array = Uint8Array.from(atob(programData), (c) =>\n        c.charCodeAt(0),\n      );\n      const buffer = Buffer.from(byteArray);\n      if (!buffer.subarray(0, 8).equals(fillDiscriminant)) {\n        continue;\n      }\n      const deserializedFillLog: FillLog = FillLog.deserialize(\n        buffer.subarray(8),\n      )[0];",
+          "endLine": 289,
+          "explanation": "Every textual `Program data:` line is decoded and accepted based only on the public discriminator.",
+          "id": "e2",
+          "label": "Log parsing ignores invocation ownership",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "root_control",
+          "startLine": 268
+        },
+        {
+          "code": "      const resultString: string = JSON.stringify(fillResult);\n      console.log('Got a fill', resultString);\n      parsedFills.push(fillResult);\n      fills.inc({\n        market: deserializedFillLog.market.toString(),\n        isGlobal: deserializedFillLog.isMakerGlobal.toString(),\n        takerIsBuy: deserializedFillLog.takerIsBuy.toString(),\n      });\n      this.wsManager.broadcast(JSON.stringify(fillResult));",
+          "endLine": 309,
+          "explanation": "The resulting object is logged, counted, and broadcast as an authentic fill.",
+          "id": "e3",
+          "label": "Accepted record is broadcast",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "sink",
+          "startLine": 301
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The signature feed obtains any transaction mentioning Manifest and scans all Program data logs without tracking their emitter; an attacker program can therefore forge accepted FillLog payloads or terminate the feed with a short discriminator-matching record."
+      },
+      "extensions": {
+        "candidateId": "candidate-5db8d2daffb3e4ef",
+        "ledgerRowId": "candidate-5db8d2daffb3e4ef"
+      },
+      "findingId": "csf_46dc5b618371095fbc4b560b",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:1bbaab3303c7d478e9b41db21be2773289c991e8f9c39494e882f5b76be6690f"
+      },
+      "identity": {
+        "anchor": "signature-fill-feed-log-provenance",
+        "instance": "signature-fill-log-provenance"
+      },
+      "locations": [
+        {
+          "endLine": 284,
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "root_control",
+          "startLine": 268
+        },
+        {
+          "endLine": 125,
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "source",
+          "startLine": 121
+        },
+        {
+          "endLine": 309,
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "sink",
+          "startLine": 287
+        }
+      ],
+      "occurrenceId": "occ_35c18165976d53b773992470",
+      "preventiveControls": [
+        "Share a single provenance-aware parser with the block feed.",
+        "Continuously replay adversarial multi-program transactions against feed regression tests."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Bind log lines to the active Solana invocation stack and accept fill data only while Manifest is the emitting frame; use parsed inner-instruction metadata as a cross-check where available.",
+      "remediationTests": [
+        "Return a signature for a transaction that references but never invokes Manifest and emits a fake fill from another program; assert zero broadcasts.",
+        "Exercise nested attacker-to-Manifest and Manifest-to-attacker CPI logs and assert only Manifest-frame data is decoded."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "Signature discovery for a program address does not authenticate which invocation emitted each transaction log line. The implementation violates that invariant along this validated path: A permissionless Solana user submits a transaction mentioning Manifest while an attacker-controlled program emits a discriminator-valid or deliberately short FillLog payload; getSignaturesForAddress returns the transaction, the signature feed scans all Program data lines without emitter binding, and it broadcasts forged data or exits parseLogs on deserialization failure."
+      },
+      "ruleId": "improper-input-validation.fill-log-emitter",
+      "severity": {
+        "changeConditions": "Raise impact only with evidence that an in-scope consumer makes irreversible financial decisions from these unauthenticated records; lower likelihood when parsing tracks and verifies the emitting invocation.",
+        "level": "medium",
+        "rationale": "Forging or terminating the shared feed is permissionless and practical, while the established harm remains false off-chain fill data and service disruption. Medium impact and high likelihood map to medium severity."
+      },
+      "summary": "The signature-based fill feed accepts any `Program data:` log in any transaction merely mentioning the Manifest address, without proving Manifest emitted it. The affected boundary is the signature-history fill-feed processor; the evidenced outcome is forged Manifest fill records delivered to signature-feed consumers.",
+      "taxonomy": {
+        "category": "Fill-log origin spoofing",
+        "cwe": [
+          "CWE-20",
+          "CWE-345"
+        ]
+      },
+      "title": "The signature-based fill feed accepts any `Program data:` log in any transaction merely mentioning the Manifest address, without proving Manifest emitted it",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: an attacker controls a program log and can include Manifest as an unused key",
+          "Exact source-control-sink path: signature selection and emitter-agnostic log parsing reach FillLog deserialization",
+          "Realistic interface/boundary: the RPC signature feed and WebSocket broadcast are concrete boundaries",
+          "Security impact beyond self-only correctness: spoofed fills violate cross-user data integrity and malformed data can stop the feed",
+          "Countercontrols/proof gaps: neither address mention nor a public discriminator proves log provenance"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "No live-chain PoC was submitted; emitter-independent parsing is directly visible and no invocation-stack control exists.",
+          "Exact downstream consumer trust varies, but the feed presents these records as Manifest fills."
+        ],
+        "method": "bounded static signature-query/log provenance trace",
+        "observations": [
+          "client/ts/src/fillFeed.ts:121-125 uses getSignaturesForAddress(PROGRAM_ID).",
+          "client/ts/src/fillFeed.ts:268-309 filters all Program data lines and validates only the FillLog discriminator before broadcasting.",
+          "Deserialization occurs inside the batch Promise flow and parseLogs ends through finally on an uncaught malformed payload."
+        ],
+        "summary": "The signature feed obtains any transaction mentioning Manifest and scans all Program data logs without tracking their emitter; an attacker program can therefore forge accepted FillLog payloads or terminate the feed with a short discriminator-matching record."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3",
+            "e4"
+          ],
+          "outcome": "remote consumption of service, RPC, and database capacity",
+          "sink": "RPC parsing, per-fill database inserts, and follow-on ticker lookups",
+          "source": "unauthenticated `GET /backfill?signature=...` requests",
+          "summary": "An unauthenticated internet caller repeatedly requests the named Fly stats service's GET /backfill with attacker-selected signatures; each request performs configured-RPC retrieval and parsing, database lookups/inserts, and ticker work, while the response timeout does not cancel underlying work."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "A public unauthenticated caller can amplify requests into shared RPC/database work and cause transient service or quota disruption. This is not protocol asset loss, so medium impact and high likelihood map to medium severity."
+        },
+        "likelihood": {
+          "level": "high",
+          "why": "A public unauthenticated caller can amplify requests into shared RPC/database work and cause transient service or quota disruption. This is not protocol asset loss, so medium impact and high likelihood map to medium severity."
+        },
+        "limitations": [
+          "Only real transaction data is parsed, inserts are conflict-aware, and unshown Fly/proxy limits or capacity may absorb traffic. Those controls can reduce practical cost but do not remove the repository-evidenced public expensive operation."
+        ],
+        "reachability": {
+          "attacker": "an unauthenticated Internet client of the deployed stats service",
+          "entrypoint": "`GET /backfill`",
+          "outcome": "remote consumption of service, RPC, and database capacity",
+          "preconditions": "The route is reachable through the deployed listener and no unshown proxy authentication/rate limit blocks abuse.",
+          "summary": "Product surface: the public mfx-stats-mainnet Fly HTTP service. Attacker: any remote unauthenticated client. Boundary: untrusted query input crosses directly into shared RPC, database, CPU, and application resources with no admission or rate control."
+        },
+        "summary": "An unauthenticated internet caller repeatedly requests the named Fly stats service's GET /backfill with attacker-selected signatures; each request performs configured-RPC retrieval and parsing, database lookups/inserts, and ticker work, while the response timeout does not cancel underlying work."
+      },
+      "codeEvidence": [
+        {
+          "code": "  const backfillHandler: RequestHandler = async (req, res) => {\n    try {\n      const signature = req.query.signature as string;\n      if (!signature) {\n        res.status(400).send({ error: 'signature parameter is required' });\n        return;\n      }\n\n      const result = await statsServer.backfillTransaction(signature);\n      res.send({",
+          "endLine": 262,
+          "explanation": "The route reads the caller-controlled signature and invokes `backfillTransaction()` without authenticating or authorizing the caller.",
+          "id": "e1",
+          "label": "Handler accepts only a query signature",
+          "language": "typescript",
+          "path": "scripts/stats-server.ts",
+          "role": "user_input",
+          "startLine": 253
+        },
+        {
+          "code": "  const app = express();\n  app.use(cors());\n\n  // HTTP request metrics middleware - tracks latency and status codes per endpoint\n  // Use a separate registry to avoid metric name collisions with the metricsApp promBundle\n  const httpApiRegistry = new promClient.Registry();\n  const httpMetrics = promBundle({\n    includeMethod: true,\n    includePath: true,\n    includeStatusCode: true,\n    promRegistry: httpApiRegistry,\n    metricsPath: '/metrics', // Expose on main app too for convenience\n    normalizePath: [\n      // Normalize paths with query params to avoid cardinality explosion\n      ['^/orderbook.*', '/orderbook'],\n      ['^/wrapper.*', '/wrapper'],\n      ['^/backfill.*', '/backfill'],\n      ['^/completeFills.*', '/completeFills'],\n      ['^/recentFills.*', '/recentFills'],\n      ['^/traders.*', '/traders'],\n    ],\n  });\n  app.use(httpMetrics);\n\n  // Global timeout middleware - 30 second timeout for all requests\n  app.use((req, res, next) => {\n    res.setTimeout(30_000, () => {\n      console.error(`Request timeout: ${req.method} ${req.path} ${req.query}`);\n      if (!res.headersSent) {\n        res.status(503).send({ error: 'Request timeout' });\n      }\n    });\n    next();",
+          "endLine": 325,
+          "explanation": "The Express application configures CORS, metrics, and a response timeout; none restrict access or cancel downstream work.",
+          "id": "e2",
+          "label": "Global middleware adds metrics and timeout but no authentication",
+          "language": "typescript",
+          "path": "scripts/stats-server.ts",
+          "role": "root_control",
+          "startLine": 293
+        },
+        {
+          "code": "  app.get('/completeFills', completeFillsHandler);\n  app.get('/alts', altsHandler);\n  app.get('/notional', notionalHandler);\n  app.get('/checkpoints', checkpointsHandler);\n  app.get('/checkpointStatus', checkpointStatusHandler);\n  app.get('/backfill', backfillHandler);",
+          "endLine": 343,
+          "explanation": "The expensive handler is mounted alongside public read endpoints.",
+          "id": "e3",
+          "label": "Backfill is registered as a public GET route",
+          "language": "typescript",
+          "path": "scripts/stats-server.ts",
+          "role": "entrypoint",
+          "startLine": 338
+        },
+        {
+          "code": "  async backfillTransaction(\n    signature: string,\n  ): Promise<{ backfilled: number; alreadyExisted: number }> {\n    if (this.isReadOnly) {\n      throw new Error('Cannot backfill in read-only mode');\n    }\n\n    // Parse fills from the transaction\n    const { fills, hasTruncatedLogs } = await parseTransactionForFills(\n      this.connection,\n      signature,\n    );\n\n    if (hasTruncatedLogs) {\n      console.warn(`Truncated logs detected during backfill for ${signature}`);\n      this.backfillRunStats.truncatedSignatures.push(signature);\n    }\n\n    if (fills.length === 0) {\n      this.recordBackfillResult(0, 0);\n      return { backfilled: 0, alreadyExisted: 0 };\n    }\n\n    let backfilled = 0;\n    let alreadyExisted = 0;\n\n    for (const fill of fills) {\n      try {\n        const result: QueryResult = await this.pool.query(\n          queries.INSERT_FILL_COMPLETE,\n          [\n            fill.slot,\n            fill.market,\n            fill.signature,\n            fill.taker,\n            fill.maker,\n            fill.takerSequenceNumber,\n            fill.makerSequenceNumber,\n            JSON.stringify(fill),\n          ],\n        );",
+          "endLine": 2106,
+          "explanation": "Each request fetches/parses a transaction and inserts every discovered fill into PostgreSQL.",
+          "id": "e4",
+          "label": "Backfill performs RPC parsing and database inserts",
+          "language": "typescript",
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "sink",
+          "startLine": 2066
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The repository's named production stats service exposes /backfill without authentication or rate limits; each attacker-chosen signature triggers RPC parsing and database writes, and response timeout does not cancel the work."
+      },
+      "extensions": {
+        "candidateId": "candidate-1ed40edc64357cdf",
+        "ledgerRowId": "candidate-1ed40edc64357cdf"
+      },
+      "findingId": "csf_149e0d66d481b0797918c768",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:3be71b5ef2593c2f8404385a6119f628142fd9927cf1976b8831f0f8cf28c07c"
+      },
+      "identity": {
+        "anchor": "stats-server-backfill-route",
+        "instance": "unauthenticated-transaction-backfill"
+      },
+      "locations": [
+        {
+          "endLine": 325,
+          "path": "scripts/stats-server.ts",
+          "role": "root_control",
+          "startLine": 293
+        },
+        {
+          "endLine": 343,
+          "path": "scripts/stats-server.ts",
+          "role": "entrypoint",
+          "startLine": 343
+        },
+        {
+          "endLine": 272,
+          "path": "scripts/stats-server.ts",
+          "role": "source",
+          "startLine": 253
+        },
+        {
+          "endLine": 2128,
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "sink",
+          "startLine": 2066
+        },
+        {
+          "endLine": 80,
+          "path": "scripts/stats_utils/backfill.ts",
+          "role": "concrete_implementation",
+          "startLine": 72
+        },
+        {
+          "endLine": 6,
+          "path": "scripts/backfill-tickers.ts",
+          "role": "evidence",
+          "startLine": 6
+        },
+        {
+          "endLine": 87,
+          "path": "scripts/backfill-tickers.ts",
+          "role": "evidence",
+          "startLine": 81
+        }
+      ],
+      "occurrenceId": "occ_c8d253dc6c0f55344a7a1033",
+      "preventiveControls": [
+        "Separate administrative mutation endpoints from the public read-only stats router.",
+        "Monitor backfill queue depth, RPC calls, database writes, and rejection rates with hard circuit breakers."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Move backfill behind authenticated operator-only `POST` access; add per-principal rate limits, bounded queues, idempotency, signature validation, and job-level RPC/database budgets.",
+      "remediationTests": [
+        "Request `/backfill` without credentials and with an unprivileged principal and assert no RPC or database call occurs.",
+        "Submit repeated and concurrent authorized requests for the same signature and assert one bounded idempotent job is queued.",
+        "Exceed per-principal and global budgets and assert requests are rejected before expensive work begins."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "summary": "A public request must not trigger RPC reads, database writes, and ticker lookups without authentication and bounded abuse controls. The implementation violates that invariant along this validated path: An unauthenticated internet caller repeatedly requests the named Fly stats service's GET /backfill with attacker-selected signatures; each request performs configured-RPC retrieval and parsing, database lookups/inserts, and ticker work, while the response timeout does not cancel underlying work."
+      },
+      "ruleId": "missing-authentication.transaction-backfill",
+      "severity": {
+        "changeConditions": "Raise impact only with evidence of persistent database corruption, severe billing exposure, or prolonged shared outage; lower likelihood if authenticated admission, cancellation, and effective rate limits are established.",
+        "level": "medium",
+        "rationale": "A public unauthenticated caller can amplify requests into shared RPC/database work and cause transient service or quota disruption. This is not protocol asset loss, so medium impact and high likelihood map to medium severity."
+      },
+      "summary": "The deployed stats server exposes an unauthenticated database-writing and RPC-consuming backfill operation. The affected boundary is `GET /backfill`; the evidenced outcome is remote consumption of service, RPC, and database capacity.",
+      "taxonomy": {
+        "category": "Missing authentication / resource exhaustion",
+        "cwe": [
+          "CWE-306",
+          "CWE-400"
+        ]
+      },
+      "title": "The deployed stats server exposes an unauthenticated database-writing and RPC-consuming backfill operation",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: an unauthenticated HTTP caller controls signature and request concurrency",
+          "Exact source-control-sink path: the route reaches getTransaction, fill parsing, and INSERT work",
+          "Realistic interface/boundary: a repository hardcoded Fly production URL invokes this route",
+          "Security impact beyond self-only correctness: concurrent calls consume shared RPC/database/application capacity and mutate records",
+          "Countercontrols/proof gaps: the 30-second response timeout is not work cancellation or admission control"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "limitations": [
+          "Capacity, upstream RPC pricing, and database limits were not measured.",
+          "The exact denial threshold is deployment-specific, but the public expensive operation and missing admission control are established."
+        ],
+        "method": "bounded static deployed-route source/control/sink trace",
+        "observations": [
+          "scripts/stats-server.ts:253-272 defines the unauthenticated handler and line 343 exposes GET /backfill.",
+          "scripts/stats_utils/manifestStatsServer.ts:2066-2128 performs RPC retrieval, parsing, and database insertion.",
+          "scripts/backfill-tickers.ts:6 and 81-87 call the production Fly endpoint's /backfill route."
+        ],
+        "summary": "The repository's named production stats service exposes /backfill without authentication or rate limits; each attacker-chosen signature triggers RPC parsing and database writes, and response timeout does not cancel the work."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "memory, file-descriptor, log, or event-loop exhaustion",
+          "sink": "per-client heartbeat state, message logging, and unconstrained broadcasts",
+          "source": "unauthenticated WebSocket connections and inbound messages",
+          "summary": "A remote unauthenticated client connects repeatedly to the feed WebSocket listener or sends large/frequent messages; the server accepts each connection, stores a heartbeat timer, and logs inbound payloads without connection, payload, message-rate, or global resource caps."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "The named public service gives low-friction access to uncapped per-client resources, supporting transient shared feed denial of service. Medium impact and high likelihood map mechanically to medium severity."
+        },
+        "likelihood": {
+          "level": "high",
+          "why": "The named public service gives low-friction access to uncapped per-client resources, supporting transient shared feed denial of service. Medium impact and high likelihood map mechanically to medium severity."
+        },
+        "limitations": [
+          "Fly or an external proxy may enforce connection and payload limits, and service capacity is unknown. No such control is configured or evidenced in the repository, so it limits confidence in the exact denial threshold rather than reachability."
+        ],
+        "reachability": {
+          "attacker": "a remote client able to reach the fill-feed port",
+          "entrypoint": "`WebSocketManager` on port 1234",
+          "outcome": "memory, file-descriptor, log, or event-loop exhaustion",
+          "preconditions": "No external Fly/proxy connection and payload limits protect the listener.",
+          "summary": "Product surface: the repository's named mfx-feed-mainnet Fly WebSocket service. Attacker: any internet client able to reach the public WSS endpoint. Boundary: unauthenticated remote connections consume shared feed-process sockets, timers, memory, CPU, and log capacity."
+        },
+        "summary": "A remote unauthenticated client connects repeatedly to the feed WebSocket listener or sends large/frequent messages; the server accepts each connection, stores a heartbeat timer, and logs inbound payloads without connection, payload, message-rate, or global resource caps."
+      },
+      "codeEvidence": [
+        {
+          "code": "  constructor(port: number, heartbeatInterval: number = 30000) {\n    this.heartbeatInterval = heartbeatInterval;\n    this.wss = new WebSocket.Server({ port });\n\n    this.wss.on('connection', (ws: WebSocket) => {\n      console.log('New client connected');\n\n      // Start heartbeat for this client\n      this.startClientHeartbeat(ws);\n\n      ws.on('message', (message: string) => {\n        console.log(`Received message: ${message}`);\n      });",
+          "endLine": 23,
+          "explanation": "The server is created with only a port, installs per-client state, and accepts arbitrary inbound message content without authentication, payload, or client limits.",
+          "id": "e1",
+          "label": "Listener accepts every connection and logs every message",
+          "language": "typescript",
+          "path": "client/ts/src/utils/WebSocketManager.ts",
+          "role": "root_control",
+          "startLine": 11
+        },
+        {
+          "code": "  public broadcast(message: string): void {\n    this.wss.clients.forEach((client) => {\n      if (client.readyState === WebSocket.OPEN) {\n        client.send(message);\n      }\n    });",
+          "endLine": 50,
+          "explanation": "Broadcast sends synchronously to all open sockets without inspecting or limiting each client's buffered output.",
+          "id": "e2",
+          "label": "Broadcast writes to every open client",
+          "language": "typescript",
+          "path": "client/ts/src/utils/WebSocketManager.ts",
+          "role": "sink",
+          "startLine": 45
+        },
+        {
+          "code": "  constructor(\n    private connection: Connection,\n    private onTruncatedLogs?: (signature: string, slot: number) => void,\n  ) {\n    this.wsManager = new WebSocketManager(1234, 30000);\n  }",
+          "endLine": 65,
+          "explanation": "Constructing the fill feed starts `WebSocketManager` on a fixed service port.",
+          "id": "e3",
+          "label": "Fill feed exposes the unrestricted listener",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "entrypoint",
+          "startLine": 60
+        }
+      ],
+      "confidence": {
+        "level": "medium",
+        "rationale": "The WebSocket server binds by port with no admission, payload, or connection cap and allocates per-client state; repository code names a deployed mfx-feed Fly WebSocket, making unauthenticated network resource exhaustion plausible."
+      },
+      "extensions": {
+        "candidateId": "candidate-6c8f15b03fcc3f88",
+        "ledgerRowId": "candidate-6c8f15b03fcc3f88"
+      },
+      "findingId": "csf_a41bf24c6194ecfb4993bdd3",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:6c6ec192df8240aacf53560c9fc3c55b70b87f0ec57c4d4d4399ef31cf005b79"
+      },
+      "identity": {
+        "anchor": "fill-feed-websocket-listener",
+        "instance": "fill-feed-websocket-resource-exhaustion"
+      },
+      "locations": [
+        {
+          "endLine": 23,
+          "path": "client/ts/src/utils/WebSocketManager.ts",
+          "role": "entrypoint",
+          "startLine": 11
+        },
+        {
+          "endLine": 77,
+          "path": "client/ts/src/utils/WebSocketManager.ts",
+          "role": "sink",
+          "startLine": 66
+        },
+        {
+          "endLine": 65,
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "concrete_implementation",
+          "startLine": 60
+        }
+      ],
+      "occurrenceId": "occ_20981d18e611fa535adc435a",
+      "preventiveControls": [
+        "Place the listener behind explicit deployment-layer connection and request-rate limits.",
+        "Monitor active clients, buffered bytes, payload rejections, and heartbeat map size."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Bind deliberately, authenticate subscribers where appropriate, set `maxPayload`, cap concurrent clients and per-IP connection rates, ignore or close on unsolicited messages, and disconnect clients whose buffered output exceeds a limit.",
+      "remediationTests": [
+        "Open connections above the global and per-IP limits and assert excess clients are rejected without growing heartbeat state.",
+        "Send an oversized message and create a slow reader during broadcasts; assert bounded memory and deterministic disconnection."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "A network listener must bound connections, payloads, message work, and per-client buffered output. The implementation violates that invariant along this validated path: A remote unauthenticated client connects repeatedly to the feed WebSocket listener or sends large/frequent messages; the server accepts each connection, stores a heartbeat timer, and logs inbound payloads without connection, payload, message-rate, or global resource caps."
+      },
+      "ruleId": "resource-exhaustion.websocket-server",
+      "severity": {
+        "changeConditions": "Lower likelihood if verified edge and application limits cap connections, payloads, and rates; raise impact only with evidence that feed loss causes broader persistent protocol or financial harm.",
+        "level": "medium",
+        "rationale": "The named public service gives low-friction access to uncapped per-client resources, supporting transient shared feed denial of service. Medium impact and high likelihood map mechanically to medium severity."
+      },
+      "summary": "The fill-feed WebSocket server exposes an unrestricted listener with no connection or inbound-message resource limits. The affected boundary is `WebSocketManager` on port 1234; the evidenced outcome is memory, file-descriptor, log, or event-loop exhaustion.",
+      "taxonomy": {
+        "category": "WebSocket resource exhaustion",
+        "cwe": [
+          "CWE-400"
+        ]
+      },
+      "title": "The fill-feed WebSocket server exposes an unrestricted listener with no connection or inbound-message resource limits",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: unauthenticated network clients control connection count and inbound payloads",
+          "Exact source-control-sink path: each connection allocates heartbeat state and messages are logged without limits",
+          "Realistic interface/boundary: the repository names wss://mfx-feed-mainnet.fly.dev as the feed endpoint",
+          "Security impact beyond self-only correctness: socket/timer/message growth can exhaust the shared feed service",
+          "Countercontrols/proof gaps: heartbeat cleanup does not cap live clients or maxPayload"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "External proxy limits and Fly deployment controls are not present in the repository and may reduce practical exposure.",
+          "Severity should remain calibrated to the unknown edge limits and service capacity."
+        ],
+        "method": "bounded static listener/config and deployment-adjacency assessment",
+        "observations": [
+          "client/ts/src/utils/WebSocketManager.ts:11-23 constructs WebSocket.Server with only port and accepts/logs every connection/message.",
+          "client/ts/src/utils/WebSocketManager.ts:66-100 stores per-client timers without a global cap.",
+          "scripts/stats_utils/manifestStatsServer.ts:809 names the deployed mfx-feed-mainnet.fly.dev endpoint."
+        ],
+        "summary": "The WebSocket server binds by port with no admission, payload, or connection cap and allocates per-client state; repository code names a deployed mfx-feed Fly WebSocket, making unauthenticated network resource exhaustion plausible."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "expensive sorts/scans, large responses, and database/service capacity loss",
+          "sink": "PostgreSQL `ORDER BY ... LIMIT ... OFFSET ...`",
+          "source": "unauthenticated `limit` and `offset` query parameters",
+          "summary": "An unauthenticated remote caller supplies very large LIMIT or OFFSET values to the named Fly stats service's /completeFills route; the values reach PostgreSQL and the application materializes and serializes all returned rows, while the response timer does not cancel query work."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "A public caller can impose disproportionate database and application work, plausibly disrupting a shared live stats service; the effect remains service availability rather than asset loss. Medium impact and high likelihood map to medium severity."
+        },
+        "likelihood": {
+          "level": "high",
+          "why": "A public caller can impose disproportionate database and application work, plausibly disrupting a shared live stats service; the effect remains service availability rather than asset loss. Medium impact and high likelihood map to medium severity."
+        },
+        "limitations": [
+          "Database size, query planner behavior, statement limits, and unshown Fly/proxy controls can reduce actual cost. They are not repository-enforced bounds and therefore do not defeat the public resource-consumption path."
+        ],
+        "reachability": {
+          "attacker": "an unauthenticated client of the public stats endpoint",
+          "entrypoint": "`GET /completeFills`",
+          "outcome": "expensive sorts/scans, large responses, and database/service capacity loss",
+          "preconditions": "The deployed database contains enough rows for large limits/offsets to consume meaningful resources and no proxy bound intervenes.",
+          "summary": "Product surface: the public mfx-stats-mainnet Fly HTTP service. Attacker: any internet client. Boundary: untrusted pagination parameters directly control shared database CPU, application memory/serialization, and response bandwidth without authentication or an application maximum."
+        },
+        "summary": "An unauthenticated remote caller supplies very large LIMIT or OFFSET values to the named Fly stats service's /completeFills route; the values reach PostgreSQL and the application materializes and serializes all returned rows, while the response timer does not cancel query work."
+      },
+      "codeEvidence": [
+        {
+          "code": "  const completeFillsHandler: RequestHandler = async (req, res) => {\n    try {\n      const options: CompleteFillsQueryOptions = {\n        market: req.query.market as string,\n        taker: req.query.taker as string,\n        maker: req.query.maker as string,\n        wallet: req.query.wallet as string,\n        signature: req.query.signature as string,\n        limit: parseInt(req.query.limit as string) || 100,\n        offset: parseInt(req.query.offset as string) || 0,\n        fromSlot: req.query.fromSlot\n          ? parseInt(req.query.fromSlot as string)\n          : undefined,\n        toSlot: req.query.toSlot\n          ? parseInt(req.query.toSlot as string)\n          : undefined,\n      };\n\n      const result = await statsServer.getCompleteFillsFromDatabase(options);",
+          "endLine": 233,
+          "explanation": "The handler parses caller-controlled `limit` and `offset` without lower or upper bounds and passes them into the stats service.",
+          "id": "e1",
+          "label": "Public query parameters become pagination options",
+          "language": "typescript",
+          "path": "scripts/stats-server.ts",
+          "role": "user_input",
+          "startLine": 215
+        },
+        {
+          "code": "  app.get('/completeFills', completeFillsHandler);",
+          "endLine": 338,
+          "explanation": "The handler is mounted without authentication or route-specific throttling.",
+          "id": "e2",
+          "label": "Complete fills is a public GET route",
+          "language": "typescript",
+          "path": "scripts/stats-server.ts",
+          "role": "entrypoint",
+          "startLine": 338
+        },
+        {
+          "code": "      const dataQuery = `\n      ${queries.SELECT_FILLS_COMPLETE_DATA_BASE}\n      ${whereClause}\n      ORDER BY slot DESC\n      LIMIT $${paramIndex++} OFFSET $${paramIndex++}\n    `;\n\n      params.push(limit, offset);\n      const dataResult = await this.executeQueryWithMetrics(\n        'SELECT_FILLS_DATA',\n        async () => this.pool.query(dataQuery, params),\n      );",
+          "endLine": 2044,
+          "explanation": "The values are appended as `LIMIT` and `OFFSET` parameters to an ordered query and executed directly.",
+          "id": "e3",
+          "label": "Unbounded values reach PostgreSQL",
+          "language": "typescript",
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "sink",
+          "startLine": 2033
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The named public stats service accepts attacker-selected LIMIT/OFFSET without positivity or maximum checks, runs the database query, and materializes the full result; the response timer does not cancel database or serialization work."
+      },
+      "extensions": {
+        "candidateId": "candidate-7776f9af1e89e3d0",
+        "ledgerRowId": "candidate-7776f9af1e89e3d0"
+      },
+      "findingId": "csf_88c6699e8cfb635e4d6cdbf7",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:a167e63f9f8b7da2bd16b27a0dcaf6d39c6f10fe9020bb24efe2354fa404e2ed"
+      },
+      "identity": {
+        "anchor": "stats-complete-fills-limit-offset",
+        "instance": "unbounded-complete-fills-pagination"
+      },
+      "locations": [
+        {
+          "endLine": 1958,
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "root_control",
+          "startLine": 1935
+        },
+        {
+          "endLine": 338,
+          "path": "scripts/stats-server.ts",
+          "role": "entrypoint",
+          "startLine": 338
+        },
+        {
+          "endLine": 399,
+          "path": "scripts/stats-server.ts",
+          "role": "entrypoint/wrapper",
+          "startLine": 397
+        },
+        {
+          "endLine": 239,
+          "path": "scripts/stats-server.ts",
+          "role": "source",
+          "startLine": 215
+        },
+        {
+          "endLine": 2048,
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "sink",
+          "startLine": 2033
+        }
+      ],
+      "occurrenceId": "occ_91ce39af7009b600be6701d4",
+      "preventiveControls": [
+        "Centralize validated pagination schemas for all stats endpoints.",
+        "Track query rows, duration, response bytes, and per-client rate-limit decisions."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Reject non-integer, negative, and excessive values; enforce a small maximum page size; replace deep offsets with cursor pagination on indexed `(slot, id)` ordering; add query timeouts and rate limits.",
+      "remediationTests": [
+        "Request negative, non-numeric, maximum-plus-one, and very large pagination values and assert a 400 response before any query.",
+        "Page through duplicate-slot data with a cursor and assert stable, gap-free bounded results.",
+        "Verify the database statement timeout cancels an intentionally expensive query."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "Public pagination inputs must be syntactically valid and capped before reaching database `LIMIT` and `OFFSET`. The implementation violates that invariant along this validated path: An unauthenticated remote caller supplies very large LIMIT or OFFSET values to the named Fly stats service's /completeFills route; the values reach PostgreSQL and the application materializes and serializes all returned rows, while the response timer does not cancel query work."
+      },
+      "ruleId": "resource-exhaustion.database-pagination",
+      "severity": {
+        "changeConditions": "Lower likelihood if strict application pagination caps, database statement limits, cancellation, and edge rate controls are added; raise impact only with evidence of persistent corruption or prolonged multi-service outage.",
+        "level": "medium",
+        "rationale": "A public caller can impose disproportionate database and application work, plausibly disrupting a shared live stats service; the effect remains service availability rather than asset loss. Medium impact and high likelihood map to medium severity."
+      },
+      "summary": "The public complete-fills endpoint accepts unrestricted database LIMIT and OFFSET values. The affected boundary is `GET /completeFills`; the evidenced outcome is expensive sorts/scans, large responses, and database/service capacity loss.",
+      "taxonomy": {
+        "category": "Unbounded pagination / resource exhaustion",
+        "cwe": [
+          "CWE-400"
+        ]
+      },
+      "title": "The public complete-fills endpoint accepts unrestricted database LIMIT and OFFSET values",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: an unauthenticated HTTP caller controls limit, offset, and concurrency",
+          "Exact source-control-sink path: the values flow into PostgreSQL LIMIT/OFFSET and response materialization",
+          "Realistic interface/boundary: the route is part of the repository-named production Fly stats service",
+          "Security impact beyond self-only correctness: large/concurrent queries consume shared DB, memory, CPU, and bandwidth",
+          "Countercontrols/proof gaps: parameter binding prevents injection but does not bound resource use"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "Practical thresholds and any external reverse-proxy limits are unknown.",
+          "The exact resource cost depends on database size, but missing application bounds are established."
+        ],
+        "method": "bounded static deployed-route query/resource trace",
+        "observations": [
+          "scripts/stats-server.ts:215-239 parses limit/offset directly and exposes /completeFills at line 338.",
+          "scripts/stats_utils/manifestStatsServer.ts:1935-1958 and 2033-2048 execute and return the selected rows.",
+          "scripts/backfill-tickers.ts:6 identifies the stats server's production Fly host."
+        ],
+        "summary": "The named public stats service accepts attacker-selected LIMIT/OFFSET without positivity or maximum checks, runs the database query, and materializes the full result; the response timer does not cancel database or serialization work."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3",
+            "e4"
+          ],
+          "outcome": "a panic that can terminate the OKX metadata worker",
+          "sink": "the unchecked slice in `get_helper()`",
+          "source": "configured RPC account bytes and their best/link indices",
+          "summary": "A malicious or compromised configured RPC returns a full-length Manifest market account whose best or link index is outside the dynamic buffer; the OKX metadata loader accepts the header, follows that index through the shared red-black-tree iterator, and reaches an unchecked Rust slice that panics."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The exact hostile-response-to-panic path is real, but exploitation requires control of the configured RPC response and yields only deployment-dependent off-chain process denial of service. Low impact and low likelihood map mechanically to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The exact hostile-response-to-panic path is real, but exploitation requires control of the configured RPC response and yields only deployment-dependent off-chain process denial of service. Low impact and low likelihood map mechanically to low severity."
+        },
+        "limitations": [
+          "Canonical Manifest-owned accounts should preserve tree invariants, and the host may catch panics or restart the worker. That is not dispositive because the repository threat model explicitly treats RPC responses as hostile, but it confines the result to narrow process availability."
+        ],
+        "reachability": {
+          "attacker": "a malicious or compromised configured RPC endpoint",
+          "entrypoint": "`Manifest::fetch_pool_metadata()`",
+          "outcome": "a panic that can terminate the OKX metadata worker",
+          "preconditions": "The integration consumes a malformed full-length market account and does not isolate the resulting panic.",
+          "summary": "Product surface: the OKX off-chain integration's pool-metadata refresh. Attacker: the configured RPC endpoint or an actor able to tamper with its response. Boundary: remote RPC bytes enter a safe decoder and can terminate the integrating process; this does not mutate on-chain state or directly affect another user's assets."
+        },
+        "summary": "A malicious or compromised configured RPC returns a full-length Manifest market account whose best or link index is outside the dynamic buffer; the OKX metadata loader accepts the header, follows that index through the shared red-black-tree iterator, and reaches an unchecked Rust slice that panics."
+      },
+      "codeEvidence": [
+        {
+          "code": "    fn fetch_pool_metadata(&self, client: &RpcClient, pool_address: &str) -> Option<PoolMetadata> {\n        let market_data = client\n            .get_account_data(&Pubkey::from_str(pool_address).ok()?)\n            .ok()?;\n        let market: MarketValue =\n            manifest::program::get_dynamic_value_or(market_data.as_slice()).ok()?;",
+          "endLine": 127,
+          "explanation": "The configured RPC supplies `market_data`, which is decoded and then traversed as a `MarketValue`.",
+          "id": "e1",
+          "label": "RPC bytes enter the market decoder",
+          "language": "rust",
+          "path": "client/okx/src/mfx.rs",
+          "role": "user_input",
+          "startLine": 122
+        },
+        {
+          "code": "    pub fn get_bids(&self) -> BooksideReadOnly {\n        let DynamicAccount { dynamic, fixed } = self.borrow_market();\n        BooksideReadOnly::new(\n            dynamic,\n            fixed.get_bids_root_index(),\n            fixed.get_bids_best_index(),\n        )",
+          "endLine": 749,
+          "explanation": "`get_bids()` forwards the stored root and best indices into `BooksideReadOnly` without proving their dynamic-buffer ranges.",
+          "id": "e2",
+          "label": "Unvalidated indices construct the bid tree",
+          "language": "rust",
+          "path": "programs/manifest/src/state/market.rs",
+          "role": "propagation",
+          "startLine": 743
+        },
+        {
+          "code": "    fn next(&mut self) -> Option<Self::Item> {\n        let index: DataIndex = self.index;\n        let next_index: DataIndex = self.tree.get_next_lower_index::<V>(self.index);\n        if index == NIL {\n            None\n        } else {\n            let result: &RBNode<V> = get_helper::<RBNode<V>>(self.tree.data(), index);\n            self.index = next_index;\n            Some((index, result.get_value()))",
+          "endLine": 915,
+          "explanation": "The iterator advances through attacker-influenced links and sends `index` to `get_helper()` without a range check.",
+          "id": "e3",
+          "label": "Iterator dereferences the selected node index",
+          "language": "rust",
+          "path": "lib/src/red_black_tree.rs",
+          "role": "root_control",
+          "startLine": 907
+        },
+        {
+          "code": "pub fn get_helper<T: Get>(data: &[u8], index: DataIndex) -> &T {\n    let index_usize: usize = index as usize;\n    bytemuck::from_bytes(&data[index_usize..index_usize + size_of::<T>()])\n}",
+          "endLine": 13,
+          "explanation": "`get_helper()` forms `data[index..index + size]`; an invalid index panics before `bytemuck` can reject the bytes.",
+          "id": "e4",
+          "label": "Unchecked slice is the panic sink",
+          "language": "rust",
+          "path": "lib/src/utils.rs",
+          "role": "sink",
+          "startLine": 10
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The OKX integration consumes RPC account bytes, trusts header/tree offsets, and reaches unchecked Rust slices; a hostile or faulty RPC response can therefore terminate the integrating process without an exact decoder countercontrol."
+      },
+      "extensions": {
+        "candidateId": "candidate-089e0e4892a70bac",
+        "ledgerRowId": "candidate-089e0e4892a70bac"
+      },
+      "findingId": "csf_25cf065a9bcaffed6bf0c47b",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:db56832071b0856ba4ee0d7af041d31b232dfcdac4bc627364624c7a778ae538"
+      },
+      "identity": {
+        "anchor": "okx-market-tree-index-decoder",
+        "instance": "rpc-tree-out-of-bounds-index"
+      },
+      "locations": [
+        {
+          "endLine": 915,
+          "path": "lib/src/red_black_tree.rs",
+          "role": "root_control",
+          "startLine": 889
+        },
+        {
+          "endLine": 749,
+          "path": "programs/manifest/src/state/market.rs",
+          "role": "root_control",
+          "startLine": 743
+        },
+        {
+          "endLine": 168,
+          "path": "client/okx/src/mfx.rs",
+          "role": "entrypoint/wrapper",
+          "startLine": 151
+        },
+        {
+          "endLine": 127,
+          "path": "client/okx/src/mfx.rs",
+          "role": "source",
+          "startLine": 122
+        },
+        {
+          "endLine": 13,
+          "path": "lib/src/utils.rs",
+          "role": "sink",
+          "startLine": 10
+        }
+      ],
+      "occurrenceId": "occ_9595e55e3b0c6a75d3c474b9",
+      "preventiveControls": [
+        "Expose only fallible hostile-byte tree readers to off-chain clients.",
+        "Run RPC decoder fuzzing and panic-free property tests in CI."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Validate every root, best, parent, left, and right index against the dynamic-buffer length and required node size before iteration; make `get_helper()` fallible and propagate a metadata-decode error instead of slicing directly.",
+      "remediationTests": [
+        "Decode a market whose best index equals and exceeds the dynamic-buffer length and assert `fetch_pool_metadata()` returns no metadata without panicking.",
+        "Fuzz tree roots and links across `NIL`, misaligned, truncated, and out-of-range values under a panic-detecting harness."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "summary": "RPC-derived tree indices must be range-checked before any dynamic-buffer slice or typed decode. The implementation violates that invariant along this validated path: A malicious or compromised configured RPC returns a full-length Manifest market account whose best or link index is outside the dynamic buffer; the OKX metadata loader accepts the header, follows that index through the shared red-black-tree iterator, and reaches an unchecked Rust slice that panics."
+      },
+      "ruleId": "improper-input-validation.tree-index",
+      "severity": {
+        "changeConditions": "Raise likelihood or impact only if a broadly used deployment is shown to consume untrusted RPC responses without panic isolation and a single response causes sustained shared service disruption.",
+        "level": "low",
+        "rationale": "The exact hostile-response-to-panic path is real, but exploitation requires control of the configured RPC response and yields only deployment-dependent off-chain process denial of service. Low impact and low likelihood map mechanically to low severity."
+      },
+      "summary": "Malformed RPC tree indices panic OKX market-metadata decoding. The affected boundary is `Manifest::fetch_pool_metadata()`; the evidenced outcome is a panic that can terminate the OKX metadata worker.",
+      "taxonomy": {
+        "category": "Out-of-bounds index / panic",
+        "cwe": [
+          "CWE-129"
+        ]
+      },
+      "title": "Malformed RPC tree indices panic OKX market-metadata decoding",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: an RPC provider controls market header and tree-link bytes",
+          "Exact source-control-sink path: out-of-range indices flow through tree iteration to get_helper",
+          "Realistic interface/boundary: fetch_pool_metadata is a concrete OKX RPC integration boundary",
+          "Security impact beyond self-only correctness: a panic can terminate a shared quote/metadata worker",
+          "Countercontrols/proof gaps: program ownership of canonical chain state does not authenticate RPC response bytes"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "limitations": [
+          "No local RPC harness was needed because the source, unchecked index, slice sink, and process boundary are exact; process-level panic policy remains deployment-dependent.",
+          "Canonical account data should have valid links, but the repository threat model explicitly treats RPC responses as hostile decoder input."
+        ],
+        "method": "bounded static RPC-to-parser source/control/sink trace",
+        "observations": [
+          "client/okx/src/mfx.rs:122-127 passes RpcClient account bytes to get_dynamic_value_or and then iterates the decoded book.",
+          "lib/src/red_black_tree.rs:889-915 follows best/link indices and calls get_helper without validating the dynamic-buffer range.",
+          "lib/src/utils.rs:10-13 uses an unchecked slice expression that panics for an out-of-range index."
+        ],
+        "summary": "The OKX integration consumes RPC account bytes, trusts header/tree offsets, and reaches unchecked Rust slices; a hostile or faulty RPC response can therefore terminate the integrating process without an exact decoder countercontrol."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2"
+          ],
+          "outcome": "quote-worker panic or invalid scaling for the affected market",
+          "sink": "unchecked `10_u64.pow()` scaling",
+          "source": "`base_decimals` and `quote_decimals` in `PoolMetadata`",
+          "summary": "A permissionless market can reference mint decimal metadata that the OKX integration copies from RPC-decoded market state into PoolMetadata; quote casts the value to u32 and passes it to unchecked 10_u64.pow, causing checked-build overflow and panic for excessive decimals."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The failure can disrupt a quote worker for an ingested market, but it neither defeats the program's transaction limits nor directly loses assets. Low impact maps to low severity even with medium likelihood."
+        },
+        "likelihood": {
+          "level": "medium",
+          "why": "The failure can disrupt a quote worker for an ingested market, but it neither defeats the program's transaction limits nor directly loses assets. Low impact maps to low severity even with medium likelihood."
+        },
+        "limitations": [
+          "The embedding host may filter listed pools, reject unusual mints, or contain panics, and those controls are not shown. The repository does enumerate Manifest markets and does not range-check decimals here, so the path remains plausible but narrowly scoped."
+        ],
+        "reachability": {
+          "attacker": "a hostile RPC provider or a permissionless market whose metadata is ingested",
+          "entrypoint": "`Manifest::quote()`",
+          "outcome": "quote-worker panic or invalid scaling for the affected market",
+          "preconditions": "The embedding router ingests an excessive decimal value and does not contain the arithmetic panic.",
+          "summary": "Product surface: OKX pool discovery and quoting. Attacker: a user who creates or causes ingestion of a Manifest market using extreme valid mint decimals, or a hostile configured RPC. Boundary: remotely sourced market metadata reaches arithmetic in the quote worker; the effect is off-chain availability or scaling corruption, not an on-chain transfer bypass."
+        },
+        "summary": "A permissionless market can reference mint decimal metadata that the OKX integration copies from RPC-decoded market state into PoolMetadata; quote casts the value to u32 and passes it to unchecked 10_u64.pow, causing checked-build overflow and panic for excessive decimals."
+      },
+      "codeEvidence": [
+        {
+          "code": "        let asks = get_extra!(metadata, \"asks\", PoolMetadataValue::Array).unwrap_or(vec![]);\n        let base_decimals =\n            get_extra!(metadata, \"base_decimals\", PoolMetadataValue::Number).unwrap_or(6.0_f64);\n        let quote_decimals =\n            get_extra!(metadata, \"quote_decimals\", PoolMetadataValue::Number).unwrap_or(6.0_f64);",
+          "endLine": 45,
+          "explanation": "The public quote path retrieves both decimal values as `f64` without validating their range or integrality.",
+          "id": "e1",
+          "label": "Quote reads unbounded decimal metadata",
+          "language": "rust",
+          "path": "client/okx/src/mfx.rs",
+          "role": "user_input",
+          "startLine": 41
+        },
+        {
+          "code": "                    let base_tokens: f64 =\n                        (base_atoms as f64) / (10_u64.pow(base_decimals as u32) as f64);\n                    let quote_tokens: f64 =\n                        (quote_atoms as f64) / (10_u64.pow(quote_decimals as u32) as f64);",
+          "endLine": 61,
+          "explanation": "Both values are cast to `u32` and passed to `10_u64.pow()` without a checked bound, allowing overflow.",
+          "id": "e2",
+          "label": "Unchecked exponentiation scales quote values",
+          "language": "rust",
+          "path": "client/okx/src/mfx.rs",
+          "role": "sink",
+          "startLine": 58
+        }
+      ],
+      "confidence": {
+        "level": "medium",
+        "rationale": "Decimal metadata can originate in RPC-decoded market headers and reaches checked u64 exponentiation without a range guard; excessive decimals can panic an OKX quote worker, although the exact downstream panic-containment policy is not shown."
+      },
+      "extensions": {
+        "candidateId": "candidate-68ee359f36ef046d",
+        "ledgerRowId": "candidate-68ee359f36ef046d"
+      },
+      "findingId": "csf_aa03373ca8c6c1021cb51a9c",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:f7a1810e4ffceee270f0202e14509d617afd713d7e14acc98cf450cc840f5831"
+      },
+      "identity": {
+        "anchor": "okx-quote-decimal-exponent",
+        "instance": "okx-decimal-pow-overflow"
+      },
+      "locations": [
+        {
+          "endLine": 32,
+          "path": "client/okx/src/mfx.rs",
+          "role": "entrypoint",
+          "startLine": 32
+        },
+        {
+          "endLine": 45,
+          "path": "client/okx/src/mfx.rs",
+          "role": "source",
+          "startLine": 41
+        },
+        {
+          "endLine": 61,
+          "path": "client/okx/src/mfx.rs",
+          "role": "sink",
+          "startLine": 58
+        }
+      ],
+      "occurrenceId": "occ_1615ed2d04e263a15d4efe7d",
+      "preventiveControls": [
+        "Represent token decimals with a bounded integer type rather than `f64` metadata.",
+        "Add property tests that every accepted decimal exponent has a representable scale."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Parse decimal metadata as a bounded integer, reject non-integral or negative values, enforce a maximum of 19 for `u64` scaling, and use checked exponentiation with an ordinary quote error.",
+      "remediationTests": [
+        "Quote with decimal values 0, 19, 20, a negative number, a fraction, and a value above `u32::MAX`; only the bounded integers should be accepted.",
+        "Feed RPC-derived metadata with excessive decimals through the quote adapter and assert no panic occurs."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "summary": "Decimal metadata must be bounded to an exponent representable by the integer scaling operation before quoting. The implementation violates that invariant along this validated path: A permissionless market can reference mint decimal metadata that the OKX integration copies from RPC-decoded market state into PoolMetadata; quote casts the value to u32 and passes it to unchecked 10_u64.pow, causing checked-build overflow and panic for excessive decimals."
+      },
+      "ruleId": "integer-overflow.decimal-scaling",
+      "severity": {
+        "changeConditions": "Increase impact only with evidence that one malicious market deterministically terminates a shared production router without isolation; reduce likelihood if deployment allowlists or decimal validation are demonstrated.",
+        "level": "low",
+        "rationale": "The failure can disrupt a quote worker for an ingested market, but it neither defeats the program's transaction limits nor directly loses assets. Low impact maps to low severity even with medium likelihood."
+      },
+      "summary": "Unvalidated decimal metadata can overflow u64 exponentiation during OKX quoting. The affected boundary is `Manifest::quote()`; the evidenced outcome is quote-worker panic or invalid scaling for the affected market.",
+      "taxonomy": {
+        "category": "Integer overflow / panic",
+        "cwe": [
+          "CWE-190",
+          "CWE-248"
+        ]
+      },
+      "title": "Unvalidated decimal metadata can overflow u64 exponentiation during OKX quoting",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC-derived or caller-supplied PoolMetadata controls the decimal values",
+          "Exact source-control-sink path: the values cast to u32 and reach 10_u64.pow without a <=19 guard",
+          "Realistic interface/boundary: the public OKX Dex quote method is a realistic integration boundary",
+          "Security impact beyond self-only correctness: a panic can disrupt a router/quote worker rather than only return a bad quote",
+          "Countercontrols/proof gaps: canonical mint metadata narrows ordinary inputs but does not validate hostile RPC bytes"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "limitations": [
+          "No end-to-end OKX host was available to establish whether its worker catches Rust panics.",
+          "The availability scope depends on the embedding host, so confidence is medium despite an exact arithmetic panic path."
+        ],
+        "method": "bounded static metadata/RPC-to-arithmetic source/control/sink trace",
+        "observations": [
+          "client/okx/src/mfx.rs:41-45 reads decimal values from PoolMetadata.",
+          "client/okx/src/mfx.rs:58-61 casts them to u32 and calls 10_u64.pow with no checked range.",
+          "client/okx/src/mfx.rs:141-149 sources the repository-generated decimal metadata from RPC-decoded market fixed data."
+        ],
+        "summary": "Decimal metadata can originate in RPC-decoded market headers and reaches checked u64 exponentiation without a range guard; excessive decimals can panic an OKX quote worker, although the exact downstream panic-containment policy is not shown."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2"
+          ],
+          "outcome": "panic in the Jupiter route/update worker",
+          "sink": "unchecked `split_at()` and `unwrap()` calls",
+          "source": "Jupiter `KeyedAccount` and `AccountMap` data",
+          "summary": "Malformed, truncated, or missing account-map data supplied to Jupiter's Amm interface reaches unchecked split_at calls and an unwrap in from_keyed_account or update, panicking before the advertised Result can carry an error."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "This is a precise recoverability failure at an SDK boundary, but it requires malformed provider data and causes only process-local availability loss. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "This is a precise recoverability failure at an SDK boundary, but it requires malformed provider data and causes only process-local availability loss. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Normal Solana RPC data for canonical program-owned accounts should be present and correctly sized, and a Jupiter host may isolate panics. Neither control is enforced in this adapter, but the unshown host containment and hostile-provider precondition keep the effect narrow."
+        ],
+        "reachability": {
+          "attacker": "a malicious or compromised RPC/account-data provider",
+          "entrypoint": "`Amm::from_keyed_account()` and `Amm::update()`",
+          "outcome": "panic in the Jupiter route/update worker",
+          "preconditions": "The host provides missing or truncated market/global account data and does not isolate panics.",
+          "summary": "Product surface: the Jupiter Manifest AMM adapter's account-ingestion/update worker. Attacker: a malicious or compromised configured RPC/account-data provider. Boundary: remote account bytes cross into a safe Result-returning SDK interface and can terminate its local worker; no on-chain authority is gained."
+        },
+        "summary": "Malformed, truncated, or missing account-map data supplied to Jupiter's Amm interface reaches unchecked split_at calls and an unwrap in from_keyed_account or update, panicking before the advertised Result can carry an error."
+      },
+      "codeEvidence": [
+        {
+          "code": "    fn from_keyed_account(keyed_account: &KeyedAccount, _amm_context: &AmmContext) -> Result<Self> {\n        let mut_data: &mut &[u8] = &mut keyed_account.account.data.as_slice();\n\n        let (header_bytes, dynamic_data) = mut_data.split_at(size_of::<MarketFixed>());\n        let market_fixed: &MarketFixed = get_helper::<MarketFixed>(header_bytes, 0_u32);",
+          "endLine": 104,
+          "explanation": "`from_keyed_account()` receives RPC bytes and immediately calls `split_at(size_of::<MarketFixed>())`.",
+          "id": "e1",
+          "label": "Keyed account is split without a length check",
+          "language": "rust",
+          "path": "client/rust/jup/src/lib.rs",
+          "role": "entrypoint",
+          "startLine": 100
+        },
+        {
+          "code": "        if let Some(global) = account_map.get(&self.get_quote_global_address()) {\n            let (header_bytes, dynamic_data) = global.data.split_at(size_of::<GlobalFixed>());\n            let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(header_bytes, 0_u32);\n            self.quote_global = Some(DynamicAccount::<GlobalFixed, Vec<u8>> {\n                fixed: *global_fixed,\n                dynamic: dynamic_data.to_vec(),\n            });\n        };\n        if let Some(global) = account_map.get(&self.get_base_global_address()) {\n            let (header_bytes, dynamic_data) = global.data.split_at(size_of::<GlobalFixed>());\n            let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(header_bytes, 0_u32);\n            self.base_global = Some(DynamicAccount::<GlobalFixed, Vec<u8>> {\n                fixed: *global_fixed,\n                dynamic: dynamic_data.to_vec(),\n            });\n        };\n\n        let market_account: &solana_account::Account = account_map.get(&self.key).unwrap();\n\n        let (header_bytes, dynamic_data) = market_account.data.split_at(size_of::<MarketFixed>());\n        let market_fixed: &MarketFixed = get_helper::<MarketFixed>(header_bytes, 0_u32);\n        self.market = DynamicAccount::<MarketFixed, Vec<u8>> {",
+          "endLine": 149,
+          "explanation": "`update()` can panic on truncated global data, a missing market map entry, or a truncated market account before its `Result` can carry an error.",
+          "id": "e2",
+          "label": "Update repeats unchecked splits and unwraps the market",
+          "language": "rust",
+          "path": "client/rust/jup/src/lib.rs",
+          "role": "root_control",
+          "startLine": 128
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The public Jupiter Amm methods return Result but perform unchecked split_at and unwrap operations on account-map data, so missing/truncated RPC accounts can panic the route worker instead of producing an ordinary update error."
+      },
+      "extensions": {
+        "candidateId": "candidate-a328d3580b33133c",
+        "ledgerRowId": "candidate-a328d3580b33133c"
+      },
+      "findingId": "csf_963ac0d9c5dd89ba9188bcc2",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:cac2c7b21c31f91ee6de5ebbc749eefa7544488800e13815e71d85d504630bc1"
+      },
+      "identity": {
+        "anchor": "jupiter-account-map-decoder",
+        "instance": "jupiter-account-data-panics"
+      },
+      "locations": [
+        {
+          "endLine": 104,
+          "path": "client/rust/jup/src/lib.rs",
+          "role": "entrypoint",
+          "startLine": 100
+        },
+        {
+          "endLine": 150,
+          "path": "client/rust/jup/src/lib.rs",
+          "role": "entrypoint",
+          "startLine": 121
+        },
+        {
+          "endLine": 104,
+          "path": "client/rust/jup/src/lib.rs",
+          "role": "sink",
+          "startLine": 103
+        },
+        {
+          "endLine": 149,
+          "path": "client/rust/jup/src/lib.rs",
+          "role": "sink",
+          "startLine": 128
+        }
+      ],
+      "occurrenceId": "occ_98b7f7aea0c685145cfc36f6",
+      "preventiveControls": [
+        "Forbid `unwrap()` and unchecked slicing in public RPC decoder modules.",
+        "Fuzz all `Amm` account-ingestion methods for panic freedom."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Replace each `split_at()` with `split_at_checked()` or an explicit length guard, replace the market lookup `unwrap()` with an error, and attach the account key and expected size to every returned error.",
+      "remediationTests": [
+        "Call `from_keyed_account()` with every length from zero through one byte below `MarketFixed` and assert an error, not a panic.",
+        "Call `update()` with a missing market and truncated base/quote global accounts and assert each case returns a contextual error."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "summary": "A `Result`-returning account-ingestion boundary must reject absent or undersized RPC accounts without panicking. The implementation violates that invariant along this validated path: Malformed, truncated, or missing account-map data supplied to Jupiter's Amm interface reaches unchecked split_at calls and an unwrap in from_keyed_account or update, panicking before the advertised Result can carry an error."
+      },
+      "ruleId": "improper-input-validation.jupiter-account-data",
+      "severity": {
+        "changeConditions": "Raise likelihood if arbitrary permissionless account-map inputs can reach these methods through a documented production router path; raise impact only if one panic causes sustained multi-market or shared routing outage.",
+        "level": "low",
+        "rationale": "This is a precise recoverability failure at an SDK boundary, but it requires malformed provider data and causes only process-local availability loss. Low impact and low likelihood map to low severity."
+      },
+      "summary": "Jupiter account ingestion panics on missing or truncated RPC account data instead of returning an error. The affected boundary is `Amm::from_keyed_account()` and `Amm::update()`; the evidenced outcome is panic in the Jupiter route/update worker.",
+      "taxonomy": {
+        "category": "Improper input validation / panic",
+        "cwe": [
+          "CWE-20",
+          "CWE-248"
+        ]
+      },
+      "title": "Jupiter account ingestion panics on missing or truncated RPC account data instead of returning an error",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC/account-map contents and presence are externally influenced",
+          "Exact source-control-sink path: missing/truncated entries reach split_at or unwrap before Result return",
+          "Realistic interface/boundary: Amm::from_keyed_account and update are concrete Jupiter plugin boundaries",
+          "Security impact beyond self-only correctness: panic can terminate shared route-worker processing",
+          "Countercontrols/proof gaps: no length/presence guard catches all named market/global paths"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "limitations": [
+          "The Jupiter host's process-level panic containment was not available locally.",
+          "Impact can range from one market update failure to worker termination depending on embedding, but the unsafe interface behavior is exact."
+        ],
+        "method": "bounded static Jupiter interface source/control/sink trace",
+        "observations": [
+          "client/rust/jup/src/lib.rs:100-104 splits keyed account data at MarketFixed size without checking length.",
+          "client/rust/jup/src/lib.rs:128-149 repeats unchecked splits for globals/market and unwraps the required market lookup.",
+          "Both methods expose anyhow::Result, so malformed input is expected to be recoverable rather than panic."
+        ],
+        "summary": "The public Jupiter Amm methods return Result but perform unchecked split_at and unwrap operations on account-map data, so missing/truncated RPC accounts can panic the route worker instead of producing an ordinary update error."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "decoder hang, exception, or memory exhaustion in a TypeScript client",
+          "sink": "unbounded tree descent/successor loops and result growth",
+          "source": "RPC-derived dynamic account bytes and root/link offsets",
+          "summary": "A hostile RPC response or supplied snapshot encodes out-of-range or cyclic red-black-tree links; Market, Global, or Wrapper loaders pass the buffer to traversal that has no bounds, visited-set, or node budget, causing a throw or non-terminating JavaScript loop."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The loop/crash is deterministic for a crafted buffer but confined to the consuming JavaScript process and normally requires a hostile data provider. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The loop/crash is deterministic for a crafted buffer but confined to the consuming JavaScript process and normally requires a hostile data provider. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Manifest-owned canonical accounts should satisfy tree invariants, and application watchdogs could restart affected workers. Those facts reduce ordinary likelihood and blast radius but are not decoder controls against the explicitly hostile RPC boundary."
+        ],
+        "reachability": {
+          "attacker": "a malicious RPC provider or actor able to corrupt account bytes before decoding",
+          "entrypoint": "`deserializeRedBlackTree()`",
+          "outcome": "decoder hang, exception, or memory exhaustion in a TypeScript client",
+          "preconditions": "An application decodes hostile bytes without a watchdog or process boundary.",
+          "summary": "Product surface: TypeScript SDK account loading. Attacker: a malicious configured RPC/snapshot provider or a caller supplying hostile account bytes. Boundary: untrusted bytes enter a public loader and can block or crash the local application process; canonical on-chain state is not modified."
+        },
+        "summary": "A hostile RPC response or supplied snapshot encodes out-of-range or cyclic red-black-tree links; Market, Global, or Wrapper loaders pass the buffer to traversal that has no bounds, visited-set, or node budget, causing a throw or non-terminating JavaScript loop."
+      },
+      "codeEvidence": [
+        {
+          "code": "export function deserializeRedBlackTree<Value>(\n  data: Buffer,\n  rootIndex: number,\n  valueDeserializer: BeetArgsStruct<Value>,\n): Value[] {\n  const result: Value[] = [];\n  const [rootHeaderValue] = redBlackTreeHeaderBeet.deserialize(\n    data.subarray(rootIndex, rootIndex + NUM_TREE_HEADER_BYTES),\n  );\n\n  // Find the min\n  let currentHeader = rootHeaderValue;\n  let currentIndex = rootIndex;\n  while (toNum(currentHeader.left) != NIL) {\n    currentIndex = toNum(currentHeader.left);\n\n    const [currentHeaderTemp] = redBlackTreeHeaderBeet.deserialize(\n      data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),\n    );\n    currentHeader = currentHeaderTemp;",
+          "endLine": 41,
+          "explanation": "The decoder slices at `rootIndex` and repeatedly assigns `currentIndex` from serialized left links without a range, alignment, or visited-set check.",
+          "id": "e1",
+          "label": "Root and left links are followed without validation",
+          "language": "typescript",
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "root_control",
+          "startLine": 22
+        },
+        {
+          "code": "  while (getSuccessorIndex(data, currentIndex) != NIL) {\n    currentIndex = getSuccessorIndex(data, currentIndex);\n    const [currentValue] = valueDeserializer.deserialize(\n      data.subarray(\n        currentIndex + NUM_TREE_HEADER_BYTES,\n        currentIndex + NUM_TREE_HEADER_BYTES + valueDeserializer.byteSize,\n      ),\n    );\n    result.push(currentValue);",
+          "endLine": 61,
+          "explanation": "Traversal repeatedly obtains a serialized successor and pushes values with no cycle or maximum-node guard.",
+          "id": "e2",
+          "label": "Successors grow the result without a node budget",
+          "language": "typescript",
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "sink",
+          "startLine": 53
+        },
+        {
+          "code": "  if (toNum(currentHeader.right) != NIL) {\n    currentIndex = toNum(currentHeader.right);\n    currentHeader = redBlackTreeHeaderBeet.deserialize(\n      data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),\n    )[0];\n    while (toNum(currentHeader.left) != NIL) {\n      currentIndex = toNum(currentHeader.left);\n      currentHeader = redBlackTreeHeaderBeet.deserialize(\n        data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),\n      )[0];\n    }",
+          "endLine": 87,
+          "explanation": "Right and left links are followed in a loop solely according to decoded node fields.",
+          "id": "e3",
+          "label": "Successor descent can loop on hostile links",
+          "language": "typescript",
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "propagation",
+          "startLine": 77
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "Public account loaders pass RPC buffers into a traversal with no bounds, alignment, node-count, or cycle validation; crafted links can deterministically throw or keep the JavaScript process in an unbounded loop."
+      },
+      "extensions": {
+        "candidateId": "candidate-4d331d2bac05630e",
+        "ledgerRowId": "candidate-4d331d2bac05630e"
+      },
+      "findingId": "csf_7b8cad88b330f13a27f506ec",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:1b27df1c2a8504ea6fde68e3cb4b060502fca447bc2bf35b6acf17abfafcbeaf"
+      },
+      "identity": {
+        "anchor": "typescript-red-black-tree-traversal",
+        "instance": "red-black-tree-hostile-buffer-traversal"
+      },
+      "locations": [
+        {
+          "endLine": 41,
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "root_control",
+          "startLine": 35
+        },
+        {
+          "endLine": 61,
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "root_control",
+          "startLine": 53
+        },
+        {
+          "endLine": 117,
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "root_control",
+          "startLine": 77
+        },
+        {
+          "endLine": 30,
+          "path": "client/ts/src/utils/redBlackTree.ts",
+          "role": "source",
+          "startLine": 22
+        },
+        {
+          "endLine": 203,
+          "path": "client/ts/src/global.ts",
+          "role": "evidence",
+          "startLine": 197
+        },
+        {
+          "endLine": 726,
+          "path": "client/ts/src/market.ts",
+          "role": "evidence",
+          "startLine": 720
+        },
+        {
+          "endLine": 266,
+          "path": "client/ts/src/wrapperObj.ts",
+          "role": "evidence",
+          "startLine": 248
+        }
+      ],
+      "occurrenceId": "occ_f3c4c76b4a5a3954dfe46b7d",
+      "preventiveControls": [
+        "Use a shared validated account-graph decoder for market, global, and wrapper trees.",
+        "Fuzz serialized graph structure with time and allocation budgets."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Validate root and link alignment/ranges, reject duplicate visited indices, cap visits by `data.length / nodeSize`, and make deserialization return a typed error on any violated invariant.",
+      "remediationTests": [
+        "Decode self-cycles, two-node cycles, out-of-range links, misaligned links, truncated nodes, and a valid maximal tree; invalid inputs must return bounded errors.",
+        "Property-test that traversal performs no more visits than the number of complete nodes in the input buffer."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "Hostile serialized trees must be validated for bounds, alignment, cycles, and a finite node budget before traversal. The implementation violates that invariant along this validated path: A hostile RPC response or supplied snapshot encodes out-of-range or cyclic red-black-tree links; Market, Global, or Wrapper loaders pass the buffer to traversal that has no bounds, visited-set, or node budget, causing a throw or non-terminating JavaScript loop."
+      },
+      "ruleId": "resource-exhaustion.red-black-tree-decoder",
+      "severity": {
+        "changeConditions": "Raise likelihood if untrusted user-uploaded snapshots or arbitrary account buffers are exposed through a live service; raise impact only if the synchronous loop causes sustained shared outage.",
+        "level": "low",
+        "rationale": "The loop/crash is deterministic for a crafted buffer but confined to the consuming JavaScript process and normally requires a hostile data provider. Low impact and low likelihood map to low severity."
+      },
+      "summary": "Red-black-tree deserialization follows untrusted node offsets without bounds, alignment, node-count, or cycle validation. The affected boundary is `deserializeRedBlackTree()`; the evidenced outcome is decoder hang, exception, or memory exhaustion in a TypeScript client.",
+      "taxonomy": {
+        "category": "Unbounded deserialization / resource exhaustion",
+        "cwe": [
+          "CWE-20",
+          "CWE-400",
+          "CWE-835"
+        ]
+      },
+      "title": "Red-black-tree deserialization follows untrusted node offsets without bounds, alignment, node-count, or cycle validation",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC/on-chain buffer bytes control root and link offsets",
+          "Exact source-control-sink path: the traversal repeatedly follows those offsets without visited/bounds controls",
+          "Realistic interface/boundary: Market, Global, and Wrapper loaders are public SDK decoding boundaries",
+          "Security impact beyond self-only correctness: cycles can hang a shared application process and bad offsets can crash loading",
+          "Countercontrols/proof gaps: program-owned canonical state does not authenticate hostile RPC responses"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "A bounded in-process PoC was not run because an intentional infinite loop would add little beyond the exact control-flow proof.",
+          "Embedding watchdogs may contain the impact, but none are present in these loaders."
+        ],
+        "method": "bounded static hostile-buffer traversal assessment",
+        "observations": [
+          "client/ts/src/utils/redBlackTree.ts:22-61 traverses left/successor links with no node budget or visited set.",
+          "client/ts/src/utils/redBlackTree.ts:67-127 repeatedly decodes attacker-selected offsets without range validation.",
+          "client/ts/src/global.ts:197-203, market.ts:720-726, and wrapperObj.ts:248-266 call this helper on account buffers."
+        ],
+        "summary": "Public account loaders pass RPC buffers into a traversal with no bounds, alignment, node-count, or cycle validation; crafted links can deterministically throw or keep the JavaScript process in an unbounded loop."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1"
+          ],
+          "outcome": "network interception can impersonate the database and alter or observe monitoring data",
+          "sink": "a `Pool` configured with `rejectUnauthorized: false`",
+          "source": "`DATABASE_URL` and network-routed PostgreSQL TLS",
+          "summary": "An attacker able to intercept or redirect the liquidity monitor's PostgreSQL connection presents any TLS certificate; rejectUnauthorized:false accepts the impersonated server, exposing database credentials and allowing monitoring queries or results to be observed or altered."
+        },
+        "evidenceRefs": [
+          "e1"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "Credential and monitoring-data compromise is meaningful, but it requires network interception or destination control. Medium impact and low likelihood map mechanically to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "Credential and monitoring-data compromise is meaningful, but it requires network interception or destination control. Medium impact and low likelihood map mechanically to low severity."
+        },
+        "limitations": [
+          "TLS still encrypts against passive observers, and Fly/private-network topology may make interception difficult. Those runtime controls are not evidenced here; they reduce likelihood but do not authenticate the configured destination."
+        ],
+        "reachability": {
+          "attacker": "an actor able to intercept or redirect the database connection",
+          "entrypoint": "`LiquidityMonitor` construction",
+          "outcome": "network interception can impersonate the database and alter or observe monitoring data",
+          "preconditions": "The deployment route is interceptable and no independent private-network authentication prevents redirection.",
+          "summary": "Product surface: the liquidity-monitoring service's database channel. Attacker: a network-positioned MITM or actor controlling the configured database destination/DNS. Boundary: the service crosses from its trusted process into an unauthenticated database endpoint using credentials from DATABASE_URL."
+        },
+        "summary": "An attacker able to intercept or redirect the liquidity monitor's PostgreSQL connection presents any TLS certificate; rejectUnauthorized:false accepts the impersonated server, exposing database credentials and allowing monitoring queries or results to be observed or altered."
+      },
+      "codeEvidence": [
+        {
+          "code": "  constructor() {\n    this.connection = new Connection(RPC_URL!);\n    this.pool = new Pool({\n      connectionString: DATABASE_URL!,\n      ssl: { rejectUnauthorized: false },\n      max: 3,\n      min: 1,\n      idleTimeoutMillis: 20000,\n      connectionTimeoutMillis: 8000,\n    });",
+          "endLine": 92,
+          "explanation": "The operational client creates its PostgreSQL pool with `rejectUnauthorized: false`, so TLS does not authenticate the configured server.",
+          "id": "e1",
+          "label": "Liquidity monitor disables certificate verification",
+          "language": "typescript",
+          "path": "scripts/liquidity-monitoring.ts",
+          "role": "root_control",
+          "startLine": 83
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The PostgreSQL client explicitly disables certificate verification while using an environment connection string, enabling a network-positioned endpoint to impersonate the database and capture credentials or alter monitoring data."
+      },
+      "extensions": {
+        "candidateId": "candidate-aacfbcb3875a450f",
+        "ledgerRowId": "candidate-aacfbcb3875a450f"
+      },
+      "findingId": "csf_d3b96d3d2dcf80a8eef0a127",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:bb31a5b389795ab2b55f2a44770617dfeab6e7205a019ba9861fcddf3cf7337b"
+      },
+      "identity": {
+        "anchor": "liquidity-monitor-postgres-connection",
+        "instance": "liquidity-monitor-postgres-tls-verification-disabled"
+      },
+      "locations": [
+        {
+          "endLine": 92,
+          "path": "scripts/liquidity-monitoring.ts",
+          "role": "sink",
+          "startLine": 83
+        }
+      ],
+      "occurrenceId": "occ_f52dbcace2524663afc71ee2",
+      "preventiveControls": [
+        "Centralize PostgreSQL connection construction so every operational script inherits verified TLS defaults.",
+        "Continuously test certificate and hostname verification in the deployment environment."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Remove `rejectUnauthorized: false`; configure the provider CA bundle and hostname verification, and fail closed when certificate validation cannot be completed.",
+      "remediationTests": [
+        "Connect through a test TLS endpoint signed by the configured trust root and assert the PostgreSQL client succeeds.",
+        "Present a wrong-host or untrusted certificate and assert connection establishment fails before any query is sent."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1"
+        ],
+        "summary": "The liquidity monitor must authenticate the PostgreSQL server before sending credentials or accepting monitoring data. The implementation violates that invariant along this validated path: An attacker able to intercept or redirect the liquidity monitor's PostgreSQL connection presents any TLS certificate; rejectUnauthorized:false accepts the impersonated server, exposing database credentials and allowing monitoring queries or results to be observed or altered."
+      },
+      "ruleId": "tls-certificate-validation.postgresql",
+      "severity": {
+        "changeConditions": "Raise likelihood if the database traverses an attacker-accessible network or destination control is available to a lower-privileged actor; lower it if certificate pinning or an authenticated private transport is established.",
+        "level": "low",
+        "rationale": "Credential and monitoring-data compromise is meaningful, but it requires network interception or destination control. Medium impact and low likelihood map mechanically to low severity."
+      },
+      "summary": "The liquidity-monitoring PostgreSQL client explicitly disables server-certificate verification. The affected boundary is `LiquidityMonitor` construction; the evidenced outcome is network interception can impersonate the database and alter or observe monitoring data.",
+      "taxonomy": {
+        "category": "Improper certificate validation",
+        "cwe": [
+          "CWE-295"
+        ]
+      },
+      "title": "The liquidity-monitoring PostgreSQL client explicitly disables server-certificate verification",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: a network-positioned actor can present an untrusted database certificate",
+          "Exact source-control-sink path: rejectUnauthorized:false removes server identity validation at Pool creation",
+          "Realistic interface/boundary: the liquidity-monitor database connection is a concrete operator/service boundary",
+          "Security impact beyond self-only correctness: database credential/data confidentiality and integrity are affected",
+          "Countercontrols/proof gaps: TLS encryption without certificate verification does not defeat impersonation"
+        ],
+        "evidenceRefs": [
+          "e1"
+        ],
+        "limitations": [
+          "Exploitability requires network interception or destination manipulation and depends on the DATABASE_URL topology.",
+          "No live database connection was attempted."
+        ],
+        "method": "bounded static transport-configuration trace",
+        "observations": [
+          "scripts/liquidity-monitoring.ts:83-92 constructs pg.Pool with ssl.rejectUnauthorized set to false.",
+          "The same client performs schema and monitoring queries through that pool."
+        ],
+        "summary": "The PostgreSQL client explicitly disables certificate verification while using an environment connection string, enabling a network-positioned endpoint to impersonate the database and capture credentials or alter monitoring data."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1"
+          ],
+          "outcome": "an intercepting peer can impersonate the snapshot database",
+          "sink": "a `Pool` configured with `rejectUnauthorized: false`",
+          "source": "`DATABASE_URL` and network-routed PostgreSQL TLS",
+          "summary": "An attacker able to intercept or redirect the snapshots service's PostgreSQL connection presents any TLS certificate; rejectUnauthorized:false accepts it, allowing capture of database credentials and observation or modification of snapshot queries and stored orderbook data."
+        },
+        "evidenceRefs": [
+          "e1"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "A successful MITM could compromise credentials and orderbook data, but the required network position or destination control is substantial and deployment evidence is incomplete. Medium impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "A successful MITM could compromise credentials and orderbook data, but the required network position or destination control is substantial and deployment evidence is incomplete. Medium impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "The standalone API was not shown deployed, and private network topology could prevent practical interception. That makes exploitation conditional but does not repair certificate authentication in the operational database client."
+        ],
+        "reachability": {
+          "attacker": "an actor able to intercept or redirect the database connection",
+          "entrypoint": "`MarketMakerLeaderboard` construction",
+          "outcome": "an intercepting peer can impersonate the snapshot database",
+          "preconditions": "The job is deployed on an interceptable route without independent endpoint authentication.",
+          "summary": "Product surface: the orderbook-snapshots service's database channel. Attacker: a network-positioned MITM or actor controlling the configured database destination/DNS. Boundary: trusted snapshot state and database credentials flow to an unauthenticated server identity."
+        },
+        "summary": "An attacker able to intercept or redirect the snapshots service's PostgreSQL connection presents any TLS certificate; rejectUnauthorized:false accepts it, allowing capture of database credentials and observation or modification of snapshot queries and stored orderbook data."
+      },
+      "codeEvidence": [
+        {
+          "code": "  constructor() {\n    this.connection = new Connection(RPC_URL!);\n    this.pool = new Pool({\n      connectionString: DATABASE_URL!,\n      ssl: { rejectUnauthorized: false },\n      max: 10,\n      min: 2,\n      idleTimeoutMillis: 30000,\n      connectionTimeoutMillis: 10000,\n    });",
+          "endLine": 58,
+          "explanation": "The snapshot client explicitly accepts an unauthenticated PostgreSQL certificate.",
+          "id": "e1",
+          "label": "Snapshot job disables certificate verification",
+          "language": "typescript",
+          "path": "scripts/orderbook-snapshots.ts",
+          "role": "root_control",
+          "startLine": 49
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The snapshots PostgreSQL connection encrypts but does not authenticate the server, so a network-positioned attacker can impersonate it and affect credentials and stored orderbook data."
+      },
+      "extensions": {
+        "candidateId": "candidate-74c9e9c82da70a20",
+        "ledgerRowId": "candidate-74c9e9c82da70a20"
+      },
+      "findingId": "csf_d3036cae005f0eca20638f7c",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:81ec0347c91d46ed7d840f3ab523adff104d4e3d79f5ab4749e2d978cc46a3ab"
+      },
+      "identity": {
+        "anchor": "orderbook-snapshots-postgres-connection",
+        "instance": "orderbook-snapshots-postgres-tls-verification-disabled"
+      },
+      "locations": [
+        {
+          "endLine": 58,
+          "path": "scripts/orderbook-snapshots.ts",
+          "role": "sink",
+          "startLine": 49
+        }
+      ],
+      "occurrenceId": "occ_731e21d318664f85222fd55d",
+      "preventiveControls": [
+        "Centralize PostgreSQL connection construction so every operational script inherits verified TLS defaults.",
+        "Continuously test certificate and hostname verification in the deployment environment."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Enable PostgreSQL certificate and hostname verification with the provider CA; make a missing or invalid trust configuration a startup error.",
+      "remediationTests": [
+        "Connect through a test TLS endpoint signed by the configured trust root and assert the PostgreSQL client succeeds.",
+        "Present a wrong-host or untrusted certificate and assert connection establishment fails before any query is sent."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1"
+        ],
+        "summary": "The orderbook snapshot job must authenticate its PostgreSQL destination before sending credentials and state. The implementation violates that invariant along this validated path: An attacker able to intercept or redirect the snapshots service's PostgreSQL connection presents any TLS certificate; rejectUnauthorized:false accepts it, allowing capture of database credentials and observation or modification of snapshot queries and stored orderbook data."
+      },
+      "ruleId": "tls-certificate-validation.postgresql",
+      "severity": {
+        "changeConditions": "Raise likelihood if this service is shown to connect across a lower-trust network; mark not applicable if the script is conclusively non-production and outside the target's operational workflows.",
+        "level": "low",
+        "rationale": "A successful MITM could compromise credentials and orderbook data, but the required network position or destination control is substantial and deployment evidence is incomplete. Medium impact and low likelihood map to low severity."
+      },
+      "summary": "The orderbook-snapshots PostgreSQL client explicitly disables server-certificate verification. The affected boundary is `MarketMakerLeaderboard` construction; the evidenced outcome is an intercepting peer can impersonate the snapshot database.",
+      "taxonomy": {
+        "category": "Improper certificate validation",
+        "cwe": [
+          "CWE-295"
+        ]
+      },
+      "title": "The orderbook-snapshots PostgreSQL client explicitly disables server-certificate verification",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: a network-positioned actor controls the presented server certificate",
+          "Exact source-control-sink path: rejectUnauthorized:false reaches the pg Pool transport",
+          "Realistic interface/boundary: the snapshots database is a concrete script/service boundary",
+          "Security impact beyond self-only correctness: credentials and database integrity/confidentiality are exposed",
+          "Countercontrols/proof gaps: no pin, CA, or independent endpoint authentication compensates"
+        ],
+        "evidenceRefs": [
+          "e1"
+        ],
+        "limitations": [
+          "Network reachability and database provider TLS details are runtime-specific.",
+          "No credential or network use occurred during validation."
+        ],
+        "method": "bounded static transport-configuration trace",
+        "observations": [
+          "scripts/orderbook-snapshots.ts:49-58 creates the Pool with ssl.rejectUnauthorized:false.",
+          "The pool is used for snapshot and order reads/writes."
+        ],
+        "summary": "The snapshots PostgreSQL connection encrypts but does not authenticate the server, so a network-positioned attacker can impersonate it and affect credentials and stored orderbook data."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1"
+          ],
+          "outcome": "database impersonation can expose or alter stats-service data",
+          "sink": "a shared `Pool` configured with `rejectUnauthorized: false`",
+          "source": "the stats server's `databaseUrl` and network-routed TLS",
+          "summary": "An attacker able to intercept or redirect the stats server's PostgreSQL connection presents any certificate; rejectUnauthorized:false accepts it, allowing capture of database credentials and manipulation of database-backed fill/statistics queries and writes."
+        },
+        "evidenceRefs": [
+          "e1"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "Database credentials and shared stats integrity are meaningful, but exploitation needs MITM or destination control not supplied by the public HTTP surface. Medium impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "Database credentials and shared stats integrity are meaningful, but exploitation needs MITM or destination control not supplied by the public HTTP surface. Medium impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "The repository names a public Fly stats endpoint, but it does not show the database network path; Fly private networking or provider controls may sharply reduce interception. That counterevidence constrains likelihood rather than defeating the missing certificate check."
+        ],
+        "reachability": {
+          "attacker": "an actor able to intercept or redirect the stats database connection",
+          "entrypoint": "`ManifestStatsServer` construction",
+          "outcome": "database impersonation can expose or alter stats-service data",
+          "preconditions": "The Fly/database path is interceptable and does not add independent endpoint authentication.",
+          "summary": "Product surface: the named production stats service's database channel. Attacker: a network-positioned MITM or actor controlling database destination/DNS, not an ordinary HTTP caller. Boundary: the live service trusts an unauthenticated PostgreSQL server identity for shared statistics state."
+        },
+        "summary": "An attacker able to intercept or redirect the stats server's PostgreSQL connection presents any certificate; rejectUnauthorized:false accepts it, allowing capture of database credentials and manipulation of database-backed fill/statistics queries and writes."
+      },
+      "codeEvidence": [
+        {
+          "code": "    this.pool = new Pool({\n      connectionString: databaseUrl,\n      ssl: { rejectUnauthorized: false }, // May be needed depending on Fly Postgres configuration\n    });",
+          "endLine": 287,
+          "explanation": "The service-wide PostgreSQL pool turns off server-certificate authentication.",
+          "id": "e1",
+          "label": "Stats server disables certificate verification",
+          "language": "typescript",
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "root_control",
+          "startLine": 284
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The stats server disables PostgreSQL certificate verification on its database connection, allowing a network-positioned attacker to impersonate the database and observe credentials or corrupt feed/statistics state."
+      },
+      "extensions": {
+        "candidateId": "candidate-10992f0a7f118550",
+        "ledgerRowId": "candidate-10992f0a7f118550"
+      },
+      "findingId": "csf_e95597872846c394009c1a3e",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:40fe4c25ebdf3f76bbf41752996ceee5383c3e98b8a31c2ecc89e3eca1dbc6fd"
+      },
+      "identity": {
+        "anchor": "stats-server-postgres-connection",
+        "instance": "stats-server-postgres-tls-verification-disabled"
+      },
+      "locations": [
+        {
+          "endLine": 287,
+          "path": "scripts/stats_utils/manifestStatsServer.ts",
+          "role": "sink",
+          "startLine": 284
+        }
+      ],
+      "occurrenceId": "occ_b4f9a539f5d7c7c4cc6969e3",
+      "preventiveControls": [
+        "Centralize PostgreSQL connection construction so every operational script inherits verified TLS defaults.",
+        "Continuously test certificate and hostname verification in the deployment environment."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Use a verified provider CA and hostname validation for the stats pool; expose an explicit development-only plaintext mode rather than disabling verification in production code.",
+      "remediationTests": [
+        "Connect through a test TLS endpoint signed by the configured trust root and assert the PostgreSQL client succeeds.",
+        "Present a wrong-host or untrusted certificate and assert connection establishment fails before any query is sent."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1"
+        ],
+        "summary": "The deployed stats service must authenticate its database before reading or writing feed records. The implementation violates that invariant along this validated path: An attacker able to intercept or redirect the stats server's PostgreSQL connection presents any certificate; rejectUnauthorized:false accepts it, allowing capture of database credentials and manipulation of database-backed fill/statistics queries and writes."
+      },
+      "ruleId": "tls-certificate-validation.postgresql",
+      "severity": {
+        "changeConditions": "Raise likelihood if a lower-privileged actor can influence DATABASE_URL, DNS, routing, or the database endpoint; reduce it if an authenticated private tunnel or certificate validation is documented.",
+        "level": "low",
+        "rationale": "Database credentials and shared stats integrity are meaningful, but exploitation needs MITM or destination control not supplied by the public HTTP surface. Medium impact and low likelihood map to low severity."
+      },
+      "summary": "The stats server PostgreSQL client explicitly disables server-certificate verification. The affected boundary is `ManifestStatsServer` construction; the evidenced outcome is database impersonation can expose or alter stats-service data.",
+      "taxonomy": {
+        "category": "Improper certificate validation",
+        "cwe": [
+          "CWE-295"
+        ]
+      },
+      "title": "The stats server PostgreSQL client explicitly disables server-certificate verification",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: a network-positioned actor can present an untrusted certificate",
+          "Exact source-control-sink path: rejectUnauthorized:false is applied at Pool construction",
+          "Realistic interface/boundary: the repository identifies the stats server as a deployed Fly service",
+          "Security impact beyond self-only correctness: database credentials and public statistics integrity are affected",
+          "Countercontrols/proof gaps: no repository countercontrol authenticates the PostgreSQL endpoint"
+        ],
+        "evidenceRefs": [
+          "e1"
+        ],
+        "limitations": [
+          "Actual network interception feasibility depends on Fly/database topology.",
+          "No live database or credential was used."
+        ],
+        "method": "bounded static transport-configuration trace",
+        "observations": [
+          "scripts/stats_utils/manifestStatsServer.ts:284-287 sets ssl.rejectUnauthorized to false.",
+          "scripts/backfill-tickers.ts:6 names the production mfx-stats-mainnet.fly.dev service, supporting an operational boundary."
+        ],
+        "summary": "The stats server disables PostgreSQL certificate verification on its database connection, allowing a network-positioned attacker to impersonate the database and observe credentials or corrupt feed/statistics state."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1"
+          ],
+          "outcome": "an intercepting database peer can manipulate the updater's work selection",
+          "sink": "an updater `Pool` configured with `rejectUnauthorized: false`",
+          "source": "`DATABASE_URL` and returned market/ALT work rows",
+          "summary": "An attacker able to intercept or redirect the ALT updater's PostgreSQL connection presents any certificate; rejectUnauthorized:false accepts it, exposing database credentials and permitting attacker-selected market rows to reach code that constructs and signs ALT-management transactions with the configured updater key."
+        },
+        "evidenceRefs": [
+          "e1"
+        ],
+        "impact": {
+          "level": "medium",
+          "why": "The path can expose database credentials and corrupt or waste a privileged ALT update, but it requires MITM/destination control and does not prove signing-key disclosure or asset loss. Medium impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The path can expose database credentials and corrupt or waste a privileged ALT update, but it requires MITM/destination control and does not prove signing-key disclosure or asset loss. Medium impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "This is operator-run tooling, the exact updater authority/value is unknown, and a database MITM does not directly obtain the Solana private key. These facts materially constrain both reach and impact, although malicious database rows can still influence signed work."
+        ],
+        "reachability": {
+          "attacker": "an actor able to intercept or redirect the updater's database connection",
+          "entrypoint": "`update-alts.ts` main routine",
+          "outcome": "an intercepting database peer can manipulate the updater's work selection",
+          "preconditions": "The operator runs the updater across an interceptable database route.",
+          "summary": "Product surface: the operator-run ALT maintenance workflow. Attacker: a network-positioned MITM or actor controlling the configured database destination/DNS. Boundary: unauthenticated database results influence a local signing workflow; the private key itself is loaded separately and is not shown to be sent to PostgreSQL."
+        },
+        "summary": "An attacker able to intercept or redirect the ALT updater's PostgreSQL connection presents any certificate; rejectUnauthorized:false accepts it, exposing database credentials and permitting attacker-selected market rows to reach code that constructs and signs ALT-management transactions with the configured updater key."
+      },
+      "codeEvidence": [
+        {
+          "code": "async function main() {\n  const connection = new Connection(RPC_URL!, 'confirmed');\n  const pool = new Pool({\n    connectionString: DATABASE_URL!,\n    ssl: { rejectUnauthorized: false }, // May be needed depending on Fly Postgres configuration\n  });\n  const keypair = Keypair.fromSecretKey(\n    Uint8Array.from(PRIVATE_KEY!.split(',').map(Number)),\n  );",
+          "endLine": 201,
+          "explanation": "The updater accepts an unauthenticated PostgreSQL peer in the same operational path that loads a signing key and consumes database-selected work.",
+          "id": "e1",
+          "label": "ALT updater disables certificate verification before loading its signer",
+          "language": "typescript",
+          "path": "scripts/update-alts.ts",
+          "role": "root_control",
+          "startLine": 193
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The privileged ALT updater disables PostgreSQL server verification; an intercepted connection can expose its database credential or supply malicious market/address data to a script that also holds a Solana private key."
+      },
+      "extensions": {
+        "candidateId": "candidate-eaf86a3678793901",
+        "ledgerRowId": "candidate-eaf86a3678793901"
+      },
+      "findingId": "csf_b8961ed598d4342b746ed1a8",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:ae68ba7e5deb9351b8559bf7186dcaef5f9ee2afedd3f72f4c40742db6499832"
+      },
+      "identity": {
+        "anchor": "update-alts-postgres-connection",
+        "instance": "update-alts-postgres-tls-verification-disabled"
+      },
+      "locations": [
+        {
+          "endLine": 198,
+          "path": "scripts/update-alts.ts",
+          "role": "sink",
+          "startLine": 193
+        }
+      ],
+      "occurrenceId": "occ_b042f6e8adc5005bd209f388",
+      "preventiveControls": [
+        "Centralize PostgreSQL connection construction so every operational script inherits verified TLS defaults.",
+        "Continuously test certificate and hostname verification in the deployment environment.",
+        "Keep the updater signer least-privileged and enforce on-chain state revalidation before every signed transaction."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Require verified PostgreSQL TLS with the provider CA and hostname, then validate every returned market/ALT row against expected on-chain ownership before signing updates.",
+      "remediationTests": [
+        "Connect through a test TLS endpoint signed by the configured trust root and assert the PostgreSQL client succeeds.",
+        "Present a wrong-host or untrusted certificate and assert connection establishment fails before any query is sent.",
+        "Return a database row for an unexpected market/ALT binding and assert the updater refuses to sign it after on-chain verification."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1"
+        ],
+        "summary": "The authority-bearing ALT updater must authenticate database rows that influence signed operational work. The implementation violates that invariant along this validated path: An attacker able to intercept or redirect the ALT updater's PostgreSQL connection presents any certificate; rejectUnauthorized:false accepts it, exposing database credentials and permitting attacker-selected market rows to reach code that constructs and signs ALT-management transactions with the configured updater key."
+      },
+      "ruleId": "tls-certificate-validation.postgresql",
+      "severity": {
+        "changeConditions": "Raise impact if the updater key is proven to control valuable non-ALT authority or attacker-selected database rows can cause broader signed state changes; raise likelihood only with evidence of a lower-trust database path.",
+        "level": "low",
+        "rationale": "The path can expose database credentials and corrupt or waste a privileged ALT update, but it requires MITM/destination control and does not prove signing-key disclosure or asset loss. Medium impact and low likelihood map to low severity."
+      },
+      "summary": "The address-lookup-table updater's PostgreSQL client explicitly disables server-certificate verification. The affected boundary is `update-alts.ts` main routine; the evidenced outcome is an intercepting database peer can manipulate the updater's work selection.",
+      "taxonomy": {
+        "category": "Improper certificate validation",
+        "cwe": [
+          "CWE-295"
+        ]
+      },
+      "title": "The address-lookup-table updater's PostgreSQL client explicitly disables server-certificate verification",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: a network-positioned actor can impersonate PostgreSQL",
+          "Exact source-control-sink path: rejectUnauthorized:false reaches the updater's Pool",
+          "Realistic interface/boundary: the operator script bridges database data and a signing-key transaction boundary",
+          "Security impact beyond self-only correctness: credential/data compromise can influence privileged ALT updates",
+          "Countercontrols/proof gaps: the comment that this may be needed for Fly is not endpoint authentication"
+        ],
+        "evidenceRefs": [
+          "e1"
+        ],
+        "limitations": [
+          "The exact authority and value of the updater key are runtime facts not established locally.",
+          "No database, RPC, or key-backed operation was attempted."
+        ],
+        "method": "bounded static transport-configuration trace",
+        "observations": [
+          "scripts/update-alts.ts:193-201 constructs the Pool with certificate verification disabled and loads PRIVATE_KEY.",
+          "scripts/update-alts.ts:204-208 uses database-selected markets while submitting signed ALT updates."
+        ],
+        "summary": "The privileged ALT updater disables PostgreSQL server verification; an intercepted connection can expose its database credential or supply malicious market/address data to a script that also holds a Solana private key."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1"
+          ],
+          "outcome": "exception or incorrect ordering during market discovery",
+          "sink": "`BN.toNumber()` in the sort comparator",
+          "source": "RPC-derived market `quoteVolume()` values represented as `BN`",
+          "summary": "RPC-loaded u64 market volume counters are represented as BN values; findByMints subtracts them and calls toNumber in the sort comparator, so a valid difference beyond JavaScript's safe integer range throws and aborts market discovery."
+        },
+        "evidenceRefs": [
+          "e1"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The valid-u64 conversion bug is exact, but attacker practicality is constrained and the effect is a client discovery failure. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The valid-u64 conversion bug is exact, but attacker practicality is constrained and the effect is a client discovery failure. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Reaching the threshold through legitimate volume may be economically expensive, canonical state constrains arbitrary values, and applications may catch the exception. These factors lower likelihood and keep the impact local."
+        ],
+        "reachability": {
+          "attacker": "a market participant able to increase a permissionless market's lifetime volume",
+          "entrypoint": "`Market.findByMints()` market discovery",
+          "outcome": "exception or incorrect ordering during market discovery",
+          "preconditions": "A returned volume difference exceeds JavaScript's safe integer range and the caller does not contain the exception.",
+          "summary": "Product surface: TypeScript SDK market discovery. Attacker: a market participant able to drive cumulative counters very high, or a hostile configured RPC. Boundary: remotely sourced market state enters a client-side numeric conversion and can make discovery unavailable; no signed transaction or on-chain state is altered."
+        },
+        "summary": "RPC-loaded u64 market volume counters are represented as BN values; findByMints subtracts them and calls toNumber in the sort comparator, so a valid difference beyond JavaScript's safe integer range throws and aborts market discovery."
+      },
+      "codeEvidence": [
+        {
+          "code": "    const accounts = await connection.getProgramAccounts(PROGRAM_ID, {\n      filters,\n    });\n\n    return accounts\n      .map(({ account, pubkey }) =>\n        Market.loadFromBuffer({ address: pubkey, buffer: account.data }),\n      )\n      .sort((a, b) =>\n        new BN(b.quoteVolume().toString())\n          .sub(new BN(a.quoteVolume().toString()))\n          .toNumber(),\n      );",
+          "endLine": 913,
+          "explanation": "RPC accounts are decoded, their lifetime volumes are subtracted as `BN`, and the arbitrary-width result is converted to `number` inside `sort()`.",
+          "id": "e1",
+          "label": "Market comparator narrows an arbitrary BN difference",
+          "language": "typescript",
+          "path": "client/ts/src/market.ts",
+          "role": "root_control",
+          "startLine": 901
+        }
+      ],
+      "confidence": {
+        "level": "medium",
+        "rationale": "Valid u64 market volume counters can exceed JavaScript's safe integer range and are converted with BN.toNumber inside a public discovery sort; influenced on-chain state can therefore make market discovery throw for all consumers of that response."
+      },
+      "extensions": {
+        "candidateId": "candidate-87797567e555958a",
+        "ledgerRowId": "candidate-87797567e555958a"
+      },
+      "findingId": "csf_9d9899701c6938fb095afeed",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:b3bbd63cac51a40179c6bc143d6a17c402f874a18cb7b21d7f65d5df98e7bf3b"
+      },
+      "identity": {
+        "anchor": "typescript-market-volume-comparator",
+        "instance": "market-volume-sort-to-number"
+      },
+      "locations": [
+        {
+          "endLine": 903,
+          "path": "client/ts/src/market.ts",
+          "role": "source",
+          "startLine": 901
+        },
+        {
+          "endLine": 913,
+          "path": "client/ts/src/market.ts",
+          "role": "sink",
+          "startLine": 905
+        }
+      ],
+      "occurrenceId": "occ_355ea61fd4701409f1078428",
+      "preventiveControls": [
+        "Ban `BN.toNumber()` in account-decoding and ordering code unless a checked safe-range assertion precedes it.",
+        "Keep on-chain integer values as `BN` or `bigint` through all comparisons."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Compare `BN` values directly with `cmp()` and return only `-1`, `0`, or `1`; never convert the difference to `number`.",
+      "remediationTests": [
+        "Sort markets with volume values around `2^53`, `u64::MAX`, and equal values and assert deterministic descending order without exceptions.",
+        "Property-test comparator antisymmetry and transitivity over arbitrary `u64` volumes."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1"
+        ],
+        "summary": "Arbitrary-width on-chain counters must not be narrowed to JavaScript `number` for ordering. The implementation violates that invariant along this validated path: RPC-loaded u64 market volume counters are represented as BN values; findByMints subtracts them and calls toNumber in the sort comparator, so a valid difference beyond JavaScript's safe integer range throws and aborts market discovery."
+      },
+      "ruleId": "numeric-conversion.market-volume-sort",
+      "severity": {
+        "changeConditions": "Raise likelihood if permissionless inexpensive state transitions can drive the relevant counter above 2^53 or hostile RPC is an accepted deployment assumption; raise impact only for sustained shared discovery failure.",
+        "level": "low",
+        "rationale": "The valid-u64 conversion bug is exact, but attacker practicality is constrained and the effect is a client discovery failure. Low impact and low likelihood map to low severity."
+      },
+      "summary": "Market discovery converts an arbitrary-size BN volume difference to Number inside its comparator. The affected boundary is `Market.findByMints()` market discovery; the evidenced outcome is exception or incorrect ordering during market discovery.",
+      "taxonomy": {
+        "category": "Numeric conversion / denial of service",
+        "cwe": [
+          "CWE-400",
+          "CWE-681"
+        ]
+      },
+      "title": "Market discovery converts an arbitrary-size BN volume difference to Number inside its comparator",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: permissionless trading can influence lifetime market volume counters",
+          "Exact source-control-sink path: BN subtraction reaches toNumber in the comparator above 2^53",
+          "Realistic interface/boundary: findByMints is a public RPC-backed SDK discovery boundary",
+          "Security impact beyond self-only correctness: one market can disrupt a shared multi-market discovery call",
+          "Countercontrols/proof gaps: on-chain u64 validity does not guarantee JavaScript safe-number range"
+        ],
+        "evidenceRefs": [
+          "e1"
+        ],
+        "limitations": [
+          "The economic effort to drive a market counter above 2^53 and downstream exception containment were not measured.",
+          "Because the affected interface is shared discovery rather than a signed transaction, the defect has plausible low availability impact."
+        ],
+        "method": "bounded static on-chain-data-to-SDK comparator trace",
+        "observations": [
+          "client/ts/src/market.ts:901-913 sorts RPC-loaded market counters by subtracting BN values and calling toNumber().",
+          "BN.js rejects unsafe integer conversion while the on-chain field is a full u64 lifetime counter."
+        ],
+        "summary": "Valid u64 market volume counters can exceed JavaScript's safe integer range and are converted with BN.toNumber inside a public discovery sort; influenced on-chain state can therefore make market discovery throw for all consumers of that response."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2"
+          ],
+          "outcome": "memory, socket, or RPC-quota exhaustion in the block feed",
+          "sink": "one unbounded `Promise.all()` of `getBlock()` requests",
+          "source": "the difference between local `currentSlot` and remote `latestSlot`",
+          "summary": "A malicious configured RPC reports an arbitrarily large latest finalized slot, or a worker restarts with a very large backlog; the block feed allocates every intervening integer and starts all getBlock requests in one Promise.all, exhausting local memory, sockets, or network capacity."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The resource drain can terminate a feed worker but requires a hostile configured RPC or unusually large backlog and has no proven persistent shared effect. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The resource drain can terminate a feed worker but requires a hostile configured RPC or unusually large backlog and has no proven persistent shared effect. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Honest Solana RPC slot progression is bounded in normal operation, the block feed may not be the selected production mode, and supervisors may restart it. These facts reduce likelihood and blast radius but do not bound the implementation."
+        ],
+        "reachability": {
+          "attacker": "a malicious or faulty configured RPC endpoint",
+          "entrypoint": "`FillFeedBlockSub.start()`",
+          "outcome": "memory, socket, or RPC-quota exhaustion in the block feed",
+          "preconditions": "The endpoint reports a large slot jump and the process/provider does not independently cap concurrency.",
+          "summary": "Product surface: the block-based fill-feed worker. Attacker: the configured RPC endpoint or an actor able to manipulate its response; an operational backlog can trigger the same failure without an attacker. Boundary: one remote slot value controls unbounded local allocation and concurrency."
+        },
+        "summary": "A malicious configured RPC reports an arbitrarily large latest finalized slot, or a worker restarts with a very large backlog; the block feed allocates every intervening integer and starts all getBlock requests in one Promise.all, exhausting local memory, sockets, or network capacity."
+      },
+      "codeEvidence": [
+        {
+          "code": "      this.currentSlot = await this.connection.getSlot('finalized');\n      console.log(`Starting block processing from slot ${this.currentSlot}`);\n\n      while (!this.shouldEnd) {\n        try {\n          // TODO: If the last one had too many, dont waste time with getSlot and just get a bunch.\n          // Get the latest finalized slot\n          const latestSlot = await this.connection.getSlot('finalized');\n\n          // Determine which slots need to be processed\n          const slotsToProcess: number[] = [];\n          for (let slot = this.currentSlot; slot <= latestSlot; slot++) {\n            slotsToProcess.push(slot);\n          }",
+          "endLine": 100,
+          "explanation": "The feed trusts the RPC's `latestSlot` and pushes every intervening integer into an in-memory array.",
+          "id": "e1",
+          "label": "Remote slot range is materialized without a bound",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "user_input",
+          "startLine": 87
+        },
+        {
+          "code": "          // Fetch all blocks in parallel\n          const blockPromises = slotsToProcess.map((slot) =>\n            this.connection.getBlock(slot, {\n              maxSupportedTransactionVersion: 0,\n              transactionDetails: 'full',\n              commitment: 'finalized',\n            }),\n          );\n\n          const blocks = await Promise.all(blockPromises);",
+          "endLine": 120,
+          "explanation": "The complete slot array becomes `getBlock()` promises passed to one `Promise.all()` with no concurrency or batch limit.",
+          "id": "e2",
+          "label": "Entire backlog is fetched concurrently",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "sink",
+          "startLine": 111
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "A remote RPC slot value controls both array growth and fully parallel block requests without a backlog or concurrency cap, permitting a malicious response or large restart gap to exhaust process memory and network resources."
+      },
+      "extensions": {
+        "candidateId": "candidate-00524c9f0e1eacfd",
+        "ledgerRowId": "candidate-00524c9f0e1eacfd"
+      },
+      "findingId": "csf_23c429e8d9748ec03f669dfc",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:fe49c83e33914462c04ff7a826be392b1cfa27e4369dffa6840fa89ed53b44bb"
+      },
+      "identity": {
+        "anchor": "block-fill-feed-slot-batch",
+        "instance": "block-feed-unbounded-slot-backlog"
+      },
+      "locations": [
+        {
+          "endLine": 100,
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "source",
+          "startLine": 87
+        },
+        {
+          "endLine": 120,
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "sink",
+          "startLine": 111
+        }
+      ],
+      "occurrenceId": "occ_688ec5b549d39ce99914b577",
+      "preventiveControls": [
+        "Expose backlog depth and in-flight RPC count as bounded service metrics.",
+        "Reject implausible remote slot regressions or jumps until independently confirmed."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Clamp acceptable slot jumps, process slots in fixed-size pages, use a concurrency-limited queue, checkpoint progress after each page, and back off on provider errors.",
+      "remediationTests": [
+        "Mock a million-slot jump and assert the implementation never allocates the full range or exceeds the configured in-flight request count.",
+        "Interrupt processing mid-page and assert restart resumes from the last durable checkpoint without refetching an unbounded backlog."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "summary": "An RPC-reported backlog must be processed with a bounded window and concurrency limit. The implementation violates that invariant along this validated path: A malicious configured RPC reports an arbitrarily large latest finalized slot, or a worker restarts with a very large backlog; the block feed allocates every intervening integer and starts all getBlock requests in one Promise.all, exhausting local memory, sockets, or network capacity."
+      },
+      "ruleId": "resource-exhaustion.block-slot-backlog",
+      "severity": {
+        "changeConditions": "Raise likelihood if the block mode is deployed against untrusted RPCs or routinely resumes after large gaps; raise impact only if one worker failure causes sustained shared feed outage.",
+        "level": "low",
+        "rationale": "The resource drain can terminate a feed worker but requires a hostile configured RPC or unusually large backlog and has no proven persistent shared effect. Low impact and low likelihood map to low severity."
+      },
+      "summary": "The block feed materializes and fetches an unbounded RPC-reported slot range in one `Promise.all`. The affected boundary is `FillFeedBlockSub.start()`; the evidenced outcome is memory, socket, or RPC-quota exhaustion in the block feed.",
+      "taxonomy": {
+        "category": "Unbounded concurrency / resource exhaustion",
+        "cwe": [
+          "CWE-400"
+        ]
+      },
+      "title": "The block feed materializes and fetches an unbounded RPC-reported slot range in one `Promise.all`",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: the RPC provider controls latestSlot and backlog size",
+          "Exact source-control-sink path: every slot is materialized and mapped to Promise.all requests",
+          "Realistic interface/boundary: the fill feed's finalized-slot RPC loop is a concrete service boundary",
+          "Security impact beyond self-only correctness: unbounded memory/concurrency can exhaust the shared feed process",
+          "Countercontrols/proof gaps: the catch/delay runs only after allocation and requests are launched"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "limitations": [
+          "No resource-exhaustion PoC was run to avoid destabilizing the validation host.",
+          "Provider honesty reduces ordinary likelihood but is not an exact control under the threat model."
+        ],
+        "method": "bounded static RPC-to-resource-allocation trace",
+        "observations": [
+          "client/ts/src/fillFeedBlockSub.ts:87-100 pushes every slot through latestSlot into an array.",
+          "client/ts/src/fillFeedBlockSub.ts:111-120 launches all getBlock calls in one Promise.all.",
+          "No maximum backlog, batch size, or semaphore is configured."
+        ],
+        "summary": "A remote RPC slot value controls both array growth and fully parallel block requests without a backlog or concurrency cap, permitting a malicious response or large restart gap to exhaust process memory and network resources."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "CPU and memory exhaustion in the OKX metadata worker",
+          "sink": "non-terminating shared red-black-tree iteration and collection",
+          "source": "configured RPC market bytes with cyclic best/parent/child links",
+          "summary": "A malicious configured RPC returns a full-length market account with an in-range self-cycle in the order tree; the shared iterator repeatedly yields the same node, and the OKX metadata loader collects it into a Vec until the process exhausts memory."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The OOM path is deterministic for a hostile response but requires configured-RPC compromise and affects only the consuming process. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The OOM path is deterministic for a hostile response but requires configured-RPC compromise and affects only the consuming process. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Canonical Manifest-owned account data should be acyclic, and a supervisor or memory limit may contain one worker. That reduces likelihood and blast radius but is not a decoder-side invariant check under the hostile-RPC threat model."
+        ],
+        "reachability": {
+          "attacker": "a malicious or compromised configured RPC endpoint",
+          "entrypoint": "`Manifest::fetch_pool_metadata()`",
+          "outcome": "CPU and memory exhaustion in the OKX metadata worker",
+          "preconditions": "The host traverses a cyclic response without process-level resource isolation.",
+          "summary": "Product surface: OKX pool-metadata refresh. Attacker: the configured RPC endpoint or an actor able to tamper with its response. Boundary: remote account bytes cross into an unbounded Rust iterator/collector and can terminate the local process; on-chain state and user assets remain unchanged."
+        },
+        "summary": "A malicious configured RPC returns a full-length market account with an in-range self-cycle in the order tree; the shared iterator repeatedly yields the same node, and the OKX metadata loader collects it into a Vec until the process exhausts memory."
+      },
+      "codeEvidence": [
+        {
+          "code": "    fn fetch_pool_metadata(&self, client: &RpcClient, pool_address: &str) -> Option<PoolMetadata> {\n        let market_data = client\n            .get_account_data(&Pubkey::from_str(pool_address).ok()?)\n            .ok()?;\n        let market: MarketValue =\n            manifest::program::get_dynamic_value_or(market_data.as_slice()).ok()?;",
+          "endLine": 127,
+          "explanation": "The configured provider controls the bytes stored in the decoded market value.",
+          "id": "e1",
+          "label": "RPC market bytes enter shared tree decoding",
+          "language": "rust",
+          "path": "client/okx/src/mfx.rs",
+          "role": "user_input",
+          "startLine": 122
+        },
+        {
+          "code": "        // Bids is an array of arrays. Top of book is first. Similar for asks.\n        // [ [baseAtoms1, quoteAtoms1], [baseAtoms2, quoteAtoms2], [baseAtoms3, quoteAtoms3], ...]\n        let bids_vec: Vec<PoolMetadataValue> = market\n            .get_bids()\n            .iter::<RestingOrder>()\n            .map(|(_ind, resting_order)| {\n                let bid = resting_order;\n                PoolMetadataValue::Array(vec![\n                    PoolMetadataValue::Number(bid.get_num_base_atoms().as_u64() as f64),\n                    PoolMetadataValue::Number(\n                        bid.get_price()\n                            .checked_quote_for_base(bid.get_num_base_atoms(), true)\n                            .unwrap()\n                            .as_u64() as f64,\n                    ),\n                ])\n            })\n            .collect::<Vec<PoolMetadataValue>>();",
+          "endLine": 168,
+          "explanation": "The loader calls `iter()` and `collect()` with no item budget, so a cyclic iterator grows work and output indefinitely.",
+          "id": "e2",
+          "label": "Metadata collection exhausts the iterator",
+          "language": "rust",
+          "path": "client/okx/src/mfx.rs",
+          "role": "sink",
+          "startLine": 151
+        },
+        {
+          "code": "    fn iter<V: Payload>(&'a self) -> HyperTreeValueReadOnlyIterator<'a, T, V> {\n        let mut index = self.get_max_index();\n        if index == NIL {\n            index = self.lookup_max_index::<V>();\n        }\n        HyperTreeValueReadOnlyIterator {\n            tree: self,\n            index,\n            phantom: std::marker::PhantomData,\n        }\n    }\n}\n\nimpl<'a, T: HyperTreeReadOperations<'a> + GetRedBlackTreeReadOnlyData<'a>, V: Payload> Iterator\n    for HyperTreeValueReadOnlyIterator<'a, T, V>\n{\n    type Item = (DataIndex, &'a V);\n\n    fn next(&mut self) -> Option<Self::Item> {\n        let index: DataIndex = self.index;\n        let next_index: DataIndex = self.tree.get_next_lower_index::<V>(self.index);\n        if index == NIL {\n            None\n        } else {\n            let result: &RBNode<V> = get_helper::<RBNode<V>>(self.tree.data(), index);\n            self.index = next_index;\n            Some((index, result.get_value()))",
+          "endLine": 915,
+          "explanation": "The iterator follows serialized next links and emits nodes without a visited set or maximum-node bound.",
+          "id": "e3",
+          "label": "Iterator has no revisit detection",
+          "language": "rust",
+          "path": "lib/src/red_black_tree.rs",
+          "role": "root_control",
+          "startLine": 889
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "A hostile RPC response can encode an in-range self-cycle that makes Rust tree iteration yield forever; the OKX metadata collector then grows a Vec until process memory exhaustion."
+      },
+      "extensions": {
+        "candidateId": "candidate-f0c3fcca9f13ffe8",
+        "ledgerRowId": "candidate-f0c3fcca9f13ffe8"
+      },
+      "findingId": "csf_ca93e169e150c729b98bb28c",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:28f564f3d5d5c68a73bf0157c11323ca0982291da387db11d645875ace235115"
+      },
+      "identity": {
+        "anchor": "okx-market-tree-cycle",
+        "instance": "rpc-tree-self-cycle"
+      },
+      "locations": [
+        {
+          "endLine": 749,
+          "path": "programs/manifest/src/state/market.rs",
+          "role": "root_control",
+          "startLine": 743
+        },
+        {
+          "endLine": 168,
+          "path": "client/okx/src/mfx.rs",
+          "role": "entrypoint/wrapper",
+          "startLine": 151
+        },
+        {
+          "endLine": 127,
+          "path": "client/okx/src/mfx.rs",
+          "role": "source",
+          "startLine": 122
+        },
+        {
+          "endLine": 658,
+          "path": "lib/src/red_black_tree.rs",
+          "role": "sink",
+          "startLine": 639
+        },
+        {
+          "endLine": 915,
+          "path": "lib/src/red_black_tree.rs",
+          "role": "sink",
+          "startLine": 889
+        }
+      ],
+      "occurrenceId": "occ_db75bce7c1040ce7d05064f8",
+      "preventiveControls": [
+        "Use one fallible graph validator for every Rust off-chain market traversal.",
+        "Fuzz graph links under time and allocation limits."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Validate the graph before iteration or carry a visited-index set and a maximum visit count derived from complete node capacity; return a decode error on any revisit.",
+      "remediationTests": [
+        "Decode self-cycles and two-node cycles through left, right, and parent links and assert bounded errors.",
+        "Property-test that metadata collection visits no index twice and performs at most one visit per complete node."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "RPC-derived tree traversal must detect revisits and enforce a node-count budget. The implementation violates that invariant along this validated path: A malicious configured RPC returns a full-length market account with an in-range self-cycle in the order tree; the shared iterator repeatedly yields the same node, and the OKX metadata loader collects it into a Vec until the process exhausts memory."
+      },
+      "ruleId": "resource-exhaustion.tree-cycle",
+      "severity": {
+        "changeConditions": "Raise likelihood if arbitrary user-controlled snapshots feed this loader or production RPC trust is weak; raise impact only if one crafted account causes sustained shared integration outage.",
+        "level": "low",
+        "rationale": "The OOM path is deterministic for a hostile response but requires configured-RPC compromise and affects only the consuming process. Low impact and low likelihood map to low severity."
+      },
+      "summary": "A cyclic RPC-supplied tree can make metadata collection iterate forever and exhaust memory. The affected boundary is `Manifest::fetch_pool_metadata()`; the evidenced outcome is CPU and memory exhaustion in the OKX metadata worker.",
+      "taxonomy": {
+        "category": "Unbounded tree traversal",
+        "cwe": [
+          "CWE-400"
+        ]
+      },
+      "title": "A cyclic RPC-supplied tree can make metadata collection iterate forever and exhaust memory",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC bytes control best, left, right, and parent indices",
+          "Exact source-control-sink path: a self-cycle makes get_next_lower_index return the same index repeatedly",
+          "Realistic interface/boundary: OKX fetch_pool_metadata collects the iterator into integration metadata",
+          "Security impact beyond self-only correctness: the loop consumes shared CPU/memory until process failure",
+          "Countercontrols/proof gaps: no visited set, node count, or authenticated RPC-byte control exists"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "No deliberate OOM PoC was run.",
+          "Canonical on-chain tree invariants are counterevidence only when the RPC transport is trusted."
+        ],
+        "method": "bounded static RPC-to-tree-iterator trace",
+        "observations": [
+          "client/okx/src/mfx.rs:151-168 collects market.get_bids().iter() into a Vec.",
+          "lib/src/red_black_tree.rs:639-658 follows unvalidated links and lines 889-915 yield each resulting index.",
+          "An in-range self-link avoids the separate out-of-bounds failure and remains non-terminating."
+        ],
+        "summary": "A hostile RPC response can encode an in-range self-cycle that makes Rust tree iteration yield forever; the OKX metadata collector then grows a Vec until process memory exhaustion."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "stack overflow, infinite loop, or worker denial of service",
+          "sink": "recursive seat lookup and iterative order traversal",
+          "source": "hostile market account bytes decoded by the slim SDK",
+          "summary": "Hostile RPC or snapshot bytes with cyclic tree links pass the slim client's fixed-header checks; find_trader_seat recurses without a depth/visited bound and order iteration follows child/parent links indefinitely, causing stack overflow or a hung local process."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The crafted-cycle failure is concrete but limited to off-chain process availability and usually requires a hostile data provider. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The crafted-cycle failure is concrete but limited to off-chain process availability and usually requires a hostile data provider. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Canonical program-owned market accounts should maintain tree invariants, and host isolation may contain failures. These controls lower likelihood and impact but do not validate hostile off-chain data at this parser boundary."
+        ],
+        "reachability": {
+          "attacker": "a hostile data provider or embedding caller supplying malformed account bytes",
+          "entrypoint": "`Market::try_from_bytes()` followed by public lookup/iterator methods",
+          "outcome": "stack overflow, infinite loop, or worker denial of service",
+          "preconditions": "An application accepts hostile bytes and invokes a traversal without panic/time isolation.",
+          "summary": "Product surface: the slim Rust SDK's market-state parser and iterators. Attacker: a malicious configured RPC/snapshot provider or caller supplying hostile account bytes. Boundary: untrusted bytes enter a safe parser and can terminate or hang the consuming process; they do not alter canonical on-chain state."
+        },
+        "summary": "Hostile RPC or snapshot bytes with cyclic tree links pass the slim client's fixed-header checks; find_trader_seat recurses without a depth/visited bound and order iteration follows child/parent links indefinitely, causing stack overflow or a hung local process."
+      },
+      "codeEvidence": [
+        {
+          "code": "impl<'a> Market<'a> {\n    /// Parse a market from raw account data.\n    pub fn try_from_bytes(data: &'a [u8]) -> Option<Self> {\n        let fixed = MarketFixed::try_from_bytes(data)?;\n        let dynamic = &data[MARKET_FIXED_SIZE..];\n        Some(Self { fixed, dynamic })",
+          "endLine": 207,
+          "explanation": "`Market::try_from_bytes()` splits fixed and dynamic regions but does not validate any tree link or cycle invariant.",
+          "id": "e1",
+          "label": "Safe parser accepts bytes without graph validation",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "entrypoint",
+          "startLine": 202
+        },
+        {
+          "code": "    fn walk_tree_for_trader(\n        &self,\n        index: DataIndex,\n        trader: &Pubkey,\n    ) -> Option<(DataIndex, &ClaimedSeat)> {\n        if index == NIL {\n            return None;\n        }\n\n        let seat = self.get_seat(index)?;\n        let seat_trader = seat.get_trader();\n\n        if &seat_trader == trader {\n            return Some((index, seat));\n        }\n\n        // Get the node header to traverse the tree\n        let offset = index as usize;\n        if offset + RBTREE_OVERHEAD_BYTES > self.dynamic.len() {\n            return None;\n        }\n        let header_ptr = self.dynamic.as_ptr().wrapping_add(offset);\n        let header = unsafe { &*(header_ptr as *const RBNodeHeader) };\n\n        // Binary search based on trader pubkey comparison\n        if trader.to_bytes() < seat_trader.to_bytes() {\n            self.walk_tree_for_trader(header.left, trader)\n        } else {\n            self.walk_tree_for_trader(header.right, trader)\n        }",
+          "endLine": 311,
+          "explanation": "The recursive search follows `left` or `right` without a visited set or depth bound.",
+          "id": "e2",
+          "label": "Seat lookup recursively follows hostile links",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 282
+        },
+        {
+          "code": "impl<'a> OrderIterator<'a> {\n    fn get_next_lower_index(&self, current: DataIndex, header: &RBNodeHeader) -> DataIndex {\n        // If there's a left child, go left then all the way right\n        if header.left != NIL {\n            let mut index = header.left;\n            loop {\n                let offset = index as usize;\n                if offset + RBTREE_OVERHEAD_BYTES > self.market.dynamic.len() {\n                    break;\n                }\n                let h = unsafe {\n                    &*(self.market.dynamic.as_ptr().wrapping_add(offset) as *const RBNodeHeader)\n                };\n                if h.right == NIL {\n                    return index;\n                }\n                index = h.right;\n            }\n            return index;\n        }\n\n        // Otherwise, go up until we come from a right child\n        let mut child = current;\n        let mut parent_idx = header.parent;\n\n        while parent_idx != NIL {\n            let offset = parent_idx as usize;\n            if offset + RBTREE_OVERHEAD_BYTES > self.market.dynamic.len() {\n                return NIL;\n            }\n            let parent_header = unsafe {\n                &*(self.market.dynamic.as_ptr().wrapping_add(offset) as *const RBNodeHeader)\n            };\n\n            if parent_header.right == child {\n                return parent_idx;\n            }\n\n            child = parent_idx;\n            parent_idx = parent_header.parent;\n        }",
+          "endLine": 409,
+          "explanation": "The iterator traverses serialized links until `NIL`; cycles remain in-range and can prevent termination.",
+          "id": "e3",
+          "label": "Order iterator loops over parent/child links",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 369
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The slim client's safe parser accepts account bytes with unchecked tree links; cycles can recurse until stack overflow or keep order iteration non-terminating, disrupting applications that parse hostile RPC data."
+      },
+      "extensions": {
+        "candidateId": "candidate-c33d863141f60b0f",
+        "ledgerRowId": "candidate-c33d863141f60b0f"
+      },
+      "findingId": "csf_67e096d10746a48cbe63da28",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:b94833179f3281ddd9d0e58e48baa7289439c955faaf44928f92b4b133db4993"
+      },
+      "identity": {
+        "anchor": "slim-market-tree-traversal",
+        "instance": "slim-cyclic-tree-links"
+      },
+      "locations": [
+        {
+          "endLine": 207,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "entrypoint",
+          "startLine": 202
+        },
+        {
+          "endLine": 279,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "source",
+          "startLine": 266
+        },
+        {
+          "endLine": 311,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 282
+        },
+        {
+          "endLine": 410,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 341
+        }
+      ],
+      "occurrenceId": "occ_b3ce302ea853a1273ae81132",
+      "preventiveControls": [
+        "Make validated ownership of account bytes explicit in the slim parser type.",
+        "Run malformed-graph fuzzing and stack-overflow detection in CI."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Validate all tree links and acyclicity during `try_from_bytes()`, or add visited sets and a node budget to both recursive and iterative traversals; return `Result` with a malformed-tree error.",
+      "remediationTests": [
+        "Construct self-cycles and multi-node cycles for seats, bids, and asks and assert every public traversal terminates with an error.",
+        "Property-test that recursion depth and iterator steps never exceed the number of complete nodes in `dynamic`."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "The slim client's safe market parser must reject cyclic tree links and bound every traversal. The implementation violates that invariant along this validated path: Hostile RPC or snapshot bytes with cyclic tree links pass the slim client's fixed-header checks; find_trader_seat recurses without a depth/visited bound and order iteration follows child/parent links indefinitely, causing stack overflow or a hung local process."
+      },
+      "ruleId": "resource-exhaustion.slim-tree-cycle",
+      "severity": {
+        "changeConditions": "Raise likelihood if arbitrary user-supplied buffers reach a live parsing service; raise impact only if one buffer causes sustained shared availability loss.",
+        "level": "low",
+        "rationale": "The crafted-cycle failure is concrete but limited to off-chain process availability and usually requires a hostile data provider. Low impact and low likelihood map to low severity."
+      },
+      "summary": "Malformed cyclic market-tree links can cause unbounded recursion or non-terminating iteration in the slim client. The affected boundary is `Market::try_from_bytes()` followed by public lookup/iterator methods; the evidenced outcome is stack overflow, infinite loop, or worker denial of service.",
+      "taxonomy": {
+        "category": "Uncontrolled recursion / iteration",
+        "cwe": [
+          "CWE-674",
+          "CWE-835"
+        ]
+      },
+      "title": "Malformed cyclic market-tree links can cause unbounded recursion or non-terminating iteration in the slim client",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC/account bytes control roots and tree links",
+          "Exact source-control-sink path: recursive seat search and iterative predecessor walks lack visited/depth limits",
+          "Realistic interface/boundary: Market::try_from_bytes and iterators are public lightweight-client APIs",
+          "Security impact beyond self-only correctness: stack overflow/hang can terminate or stall a shared application",
+          "Countercontrols/proof gaps: length checks prevent some OOB reads but do not defeat in-range cycles"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "No deliberate stack-overflow or infinite-loop PoC was run.",
+          "Canonical on-chain ownership narrows ordinary corruption, but hostile RPC/snapshot bytes remain a documented client boundary."
+        ],
+        "method": "bounded static hostile-buffer recursion/iteration assessment",
+        "observations": [
+          "client/rust/slim/src/state.rs:202-207 validates only header size/discriminant.",
+          "Lines 282-311 recursively follow claimed-seat links with no depth or visited control.",
+          "Lines 341-410 iterate child/parent links without cycle detection."
+        ],
+        "summary": "The slim client's safe parser accepts account bytes with unchecked tree links; cycles can recurse until stack overflow or keep order iteration non-terminating, disrupting applications that parse hostile RPC data."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3"
+          ],
+          "outcome": "under-counted, omitted, or distorted inferred fill records",
+          "sink": "coarse nested-loop subtraction by market, taker, and side",
+          "source": "parsed and inferred fills from a truncated multi-invocation transaction",
+          "summary": "A transaction with truncated logs contains multiple same-market, same-taker, same-side swaps; reconciliation matches only those coarse fields and subtracts every parsed fill from every inferred fill, then both feed implementations broadcast suppressed or undercounted remainders."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The reachable flaw corrupts off-chain feed accounting under specific transaction conditions but does not fabricate on-chain transfers or directly lose assets. Low impact maps to low severity at medium likelihood."
+        },
+        "likelihood": {
+          "level": "medium",
+          "why": "The reachable flaw corrupts off-chain feed accounting under specific transaction conditions but does not fabricate on-chain transfers or directly lose assets. Low impact maps to low severity at medium likelihood."
+        },
+        "limitations": [
+          "The transaction still contains authentic swaps, consumers may independently verify them, and exploitation requires a specific multi-invocation/truncation shape. Those facts constrain likelihood and impact but do not fix the deterministic cross-invocation association error."
+        ],
+        "reachability": {
+          "attacker": "a transaction composer able to create multiple matching swaps and trigger log truncation",
+          "entrypoint": "`computeInferredRemainders()` in both feed modes",
+          "outcome": "under-counted, omitted, or distorted inferred fill records",
+          "preconditions": "Multiple invocations share market, taker, and side and at least one emitted log survives truncation.",
+          "summary": "Product surface: both off-chain fill-feed implementations during supported truncated-log recovery. Attacker: a permissionless transaction submitter able to construct multiple matching swaps and induce or encounter log truncation. Boundary: valid transaction data is misassociated and crosses into shared off-chain fill records; canonical on-chain fills remain unchanged."
+        },
+        "summary": "A transaction with truncated logs contains multiple same-market, same-taker, same-side swaps; reconciliation matches only those coarse fields and subtracts every parsed fill from every inferred fill, then both feed implementations broadcast suppressed or undercounted remainders."
+      },
+      "codeEvidence": [
+        {
+          "code": "export function computeInferredRemainders(\n  inferred: FillLogResult[],\n  parsed: FillLogResult[],\n): FillLogResult[] {\n  const remainders: FillLogResult[] = [];\n  for (const fill of inferred) {\n    let baseAtoms: bigint = BigInt(fill.baseAtoms);\n    let quoteAtoms: bigint = BigInt(fill.quoteAtoms);\n    for (const parsedFill of parsed) {\n      if (\n        parsedFill.market === fill.market &&\n        parsedFill.taker === fill.taker &&\n        parsedFill.takerIsBuy === fill.takerIsBuy\n      ) {\n        baseAtoms -= BigInt(parsedFill.baseAtoms);\n        quoteAtoms -= BigInt(parsedFill.quoteAtoms);\n      }\n    }\n    if (baseAtoms > 0n && quoteAtoms > 0n) {\n      remainders.push({\n        ...fill,\n        baseAtoms: baseAtoms.toString(),\n        quoteAtoms: quoteAtoms.toString(),\n        priceAtoms: Number(quoteAtoms) / Number(baseAtoms),\n      });",
+          "endLine": 383,
+          "explanation": "For each inferred fill, the function subtracts every parsed fill sharing only market, taker, and side, with no invocation identity or one-time consumption.",
+          "id": "e1",
+          "label": "Coarse keys drive repeated subtraction",
+          "language": "typescript",
+          "path": "client/ts/src/utils/inferFills.ts",
+          "role": "root_control",
+          "startLine": 359
+        },
+        {
+          "code": "    if (truncated) {\n      const inferred: FillLogResult[] = computeInferredRemainders(\n        inferFillsFromTransaction(tx, signature.signature, signature.slot, {\n          originalSigner,\n          aggregator,\n          originatingProtocol,\n          signers,\n          blockTime: signature.blockTime ?? undefined,\n        }),\n        parsedFills,\n      );\n      for (const inferredFill of inferred) {\n        console.log('Inferred a fill', JSON.stringify(inferredFill));\n        inferredFills.inc({ market: inferredFill.market });\n        this.wsManager.broadcast(JSON.stringify(inferredFill));",
+          "endLine": 329,
+          "explanation": "The signature feed applies the shared reconciliation after truncated logs and broadcasts every returned remainder.",
+          "id": "e2",
+          "label": "Signature feed broadcasts reconciled results",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "sink",
+          "startLine": 315
+        },
+        {
+          "code": "    if (truncated) {\n      const inferred: FillLogResult[] = computeInferredRemainders(\n        inferFillsFromTransaction(tx, signature, slot, {\n          originalSigner,\n          aggregator,\n          originatingProtocol,\n          signers,\n          blockTime: blockTime ?? undefined,\n        }),\n        parsedFills,\n      );\n      for (const inferredFill of inferred) {\n        console.log('Inferred a fill', JSON.stringify(inferredFill));\n        inferredFills.inc({ market: inferredFill.market });\n        this.wsManager.broadcast(JSON.stringify(inferredFill));",
+          "endLine": 364,
+          "explanation": "The block feed applies the same coarse matching and broadcasts its inferred remainders.",
+          "id": "e3",
+          "label": "Block feed uses the same reconciliation",
+          "language": "typescript",
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "sink",
+          "startLine": 350
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "For truncated logs, every parsed fill matching only market/taker/side is subtracted from every inferred fill with those fields; a transaction containing multiple same-side swaps can suppress unrelated inferred fills broadcast by both feed implementations."
+      },
+      "extensions": {
+        "candidateId": "candidate-0cada416f736ad7c",
+        "ledgerRowId": "candidate-0cada416f736ad7c"
+      },
+      "findingId": "csf_72c0e3f12fcd734fe008472f",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:66322d679065a8269ba5985fac609a3e8a3fbfb96c2f74e16d87628d9636025f"
+      },
+      "identity": {
+        "anchor": "truncated-fill-cross-invocation-matching",
+        "instance": "inferred-fill-cross-invocation-subtraction"
+      },
+      "locations": [
+        {
+          "endLine": 375,
+          "path": "client/ts/src/utils/inferFills.ts",
+          "role": "root_control",
+          "startLine": 359
+        },
+        {
+          "endLine": 383,
+          "path": "client/ts/src/utils/inferFills.ts",
+          "role": "sink",
+          "startLine": 377
+        },
+        {
+          "endLine": 329,
+          "path": "client/ts/src/fillFeed.ts",
+          "role": "concrete_implementation",
+          "startLine": 315
+        },
+        {
+          "endLine": 364,
+          "path": "client/ts/src/fillFeedBlockSub.ts",
+          "role": "concrete_implementation",
+          "startLine": 350
+        }
+      ],
+      "occurrenceId": "occ_e78ffc7b1556ecc21b1bc103",
+      "preventiveControls": [
+        "Carry invocation identity through log parsing, transfer inference, and the public fill schema.",
+        "Add transaction-level conservation properties for truncated-log reconciliation."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Associate parsed and inferred fills by instruction/invocation index plus sequence numbers or a deterministic transfer/log identity; consume each parsed fill at most once and reject ambiguous reconciliation.",
+      "remediationTests": [
+        "Reconcile two same-market, same-taker, same-side invocations with one surviving parsed fill and assert only its matching inferred record is reduced.",
+        "Randomize invocation/log/transfer order and assert total base/quote atoms are conserved without double subtraction."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "summary": "A parsed fill may reduce only the inferred fill from the same invocation/order identity, not every record sharing coarse attributes. The implementation violates that invariant along this validated path: A transaction with truncated logs contains multiple same-market, same-taker, same-side swaps; reconciliation matches only those coarse fields and subtracts every parsed fill from every inferred fill, then both feed implementations broadcast suppressed or undercounted remainders."
+      },
+      "ruleId": "improper-input-validation.fill-reconciliation",
+      "severity": {
+        "changeConditions": "Raise impact only if a repository-backed consumer makes irreversible financial decisions from unreconciled feed output; lower likelihood if invocation/order identity is added to reconciliation.",
+        "level": "low",
+        "rationale": "The reachable flaw corrupts off-chain feed accounting under specific transaction conditions but does not fabricate on-chain transfers or directly lose assets. Low impact maps to low severity at medium likelihood."
+      },
+      "summary": "Truncated-log reconciliation subtracts every matching parsed fill from every inferred fill sharing only market, taker, and side. The affected boundary is `computeInferredRemainders()` in both feed modes; the evidenced outcome is under-counted, omitted, or distorted inferred fill records.",
+      "taxonomy": {
+        "category": "Fill reconciliation integrity error",
+        "cwe": [
+          "CWE-682"
+        ]
+      },
+      "title": "Truncated-log reconciliation subtracts every matching parsed fill from every inferred fill sharing only market, taker, and side",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: a transaction author controls multiple swap invocations and their shared fields",
+          "Exact source-control-sink path: the nested loop lacks invocation/order/transfer association",
+          "Realistic interface/boundary: both public fill feeds broadcast the reconciled result",
+          "Security impact beyond self-only correctness: downstream fill-record integrity is corrupted across invocations",
+          "Countercontrols/proof gaps: amount clamping does not restore one-to-one provenance"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3"
+        ],
+        "limitations": [
+          "A crafted finalized transaction was not submitted; exact affected amounts depend on transfer/log ordering.",
+          "Consumers that independently verify fills may contain impact, but no such feed guarantee is present."
+        ],
+        "method": "bounded static multi-invocation reconciliation trace",
+        "observations": [
+          "client/ts/src/utils/inferFills.ts:359-383 matches only market, taker, and side in a nested all-to-all subtraction.",
+          "client/ts/src/fillFeed.ts:315-329 and fillFeedBlockSub.ts:350-364 broadcast the returned remainders.",
+          "Log truncation is an explicit supported condition in both feed paths."
+        ],
+        "summary": "For truncated logs, every parsed fill matching only market/taker/side is subtracted from every inferred fill with those fields; a transaction containing multiple same-side swaps can suppress unrelated inferred fills broadcast by both feed implementations."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3",
+            "e4"
+          ],
+          "outcome": "undefined behavior with deployment-dependent crash or misbehavior",
+          "sink": "raw pointer casts to `&MarketFixed`, `&RestingOrder`, `&ClaimedSeat`, and `&RBNodeHeader`",
+          "source": "an arbitrary safe caller-provided `&[u8]` and dynamic indices",
+          "summary": "A safe caller passes a sufficiently long but unaligned byte slice to the slim client's parsing API; the implementation casts its pointer and dynamic offsets to aligned Rust types and creates typed references, violating alignment requirements and invoking undefined behavior."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The Rust validity violation is exact, yet a realistic remote attacker-controlled alignment path and exploitation beyond local crash/misbehavior are not demonstrated. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The Rust validity violation is exact, yet a realistic remote attacker-controlled alignment path and exploitation beyond local crash/misbehavior are not demonstrated. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Common allocators and call sites may provide aligned base buffers, and tolerant hardware may not visibly fault. This does not make the safe API sound, but it makes attacker-controlled alignment and major exploitation unproven."
+        ],
+        "reachability": {
+          "attacker": "a hostile data provider where an embedding application exposes an unaligned subslice, or any safe caller",
+          "entrypoint": "`MarketFixed::try_from_bytes()` and `Market` accessors",
+          "outcome": "undefined behavior with deployment-dependent crash or misbehavior",
+          "preconditions": "The slice base or dynamic offset is not aligned for the referenced Rust type.",
+          "summary": "Product surface: the reusable slim Rust SDK parser. Attacker: a hostile data provider only where an embedding application exposes its bytes through an unaligned slice, or an ordinary safe caller that constructs such a subslice. Boundary: bytes cross a purportedly safe API into unsafe typed references; the demonstrated consequence is local parser unsoundness, not proven code execution or on-chain compromise."
+        },
+        "summary": "A safe caller passes a sufficiently long but unaligned byte slice to the slim client's parsing API; the implementation casts its pointer and dynamic offsets to aligned Rust types and creates typed references, violating alignment requirements and invoking undefined behavior."
+      },
+      "codeEvidence": [
+        {
+          "code": "impl MarketFixed {\n    /// Parse a MarketFixed from bytes.\n    pub fn try_from_bytes(data: &[u8]) -> Option<&Self> {\n        if data.len() < MARKET_FIXED_SIZE {\n            return None;\n        }\n\n        // Safety: We've verified the length is sufficient\n        let fixed = unsafe { &*(data.as_ptr() as *const MarketFixed) };\n",
+          "endLine": 72,
+          "explanation": "A safe method turns `data.as_ptr()` into `&MarketFixed` after only a size check; callers may supply an unaligned subslice.",
+          "id": "e1",
+          "label": "Safe header parser checks length but not alignment",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "root_control",
+          "startLine": 63
+        },
+        {
+          "code": "    /// Get a resting order at the given index.\n    pub fn get_order(&self, index: DataIndex) -> Option<&RestingOrder> {\n        if index == NIL {\n            return None;\n        }\n        let offset = index as usize;\n        if offset + RBTREE_OVERHEAD_BYTES + RESTING_ORDER_SIZE > self.dynamic.len() {\n            return None;\n        }\n        // Skip the RBNode header\n        let order_ptr = self\n            .dynamic\n            .as_ptr()\n            .wrapping_add(offset + RBTREE_OVERHEAD_BYTES);\n        Some(unsafe { &*(order_ptr as *const RestingOrder) })\n    }\n\n    /// Get a claimed seat at the given index.\n    pub fn get_seat(&self, index: DataIndex) -> Option<&ClaimedSeat> {\n        if index == NIL {\n            return None;\n        }\n        let offset = index as usize;\n        if offset + RBTREE_OVERHEAD_BYTES + CLAIMED_SEAT_SIZE > self.dynamic.len() {\n            return None;\n        }\n        // Skip the RBNode header\n        let seat_ptr = self\n            .dynamic\n            .as_ptr()\n            .wrapping_add(offset + RBTREE_OVERHEAD_BYTES);\n        Some(unsafe { &*(seat_ptr as *const ClaimedSeat) })",
+          "endLine": 251,
+          "explanation": "Length-checked but potentially unaligned dynamic pointers are cast to aligned typed references.",
+          "id": "e2",
+          "label": "Dynamic order and seat offsets become references",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 220
+        },
+        {
+          "code": "        // Get the node header to traverse the tree\n        let offset = index as usize;\n        if offset + RBTREE_OVERHEAD_BYTES > self.dynamic.len() {\n            return None;\n        }\n        let header_ptr = self.dynamic.as_ptr().wrapping_add(offset);\n        let header = unsafe { &*(header_ptr as *const RBNodeHeader) };",
+          "endLine": 304,
+          "explanation": "The attacker-influenced node offset is converted to `&RBNodeHeader` without checking its alignment.",
+          "id": "e3",
+          "label": "Tree header is cast without alignment proof",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 298
+        },
+        {
+          "code": "        let index = self.current_index;\n        let order = *self.market.get_order(index)?;\n\n        // Get the next index by traversing the tree\n        let offset = index as usize;\n        if offset + RBTREE_OVERHEAD_BYTES > self.market.dynamic.len() {\n            self.current_index = NIL;\n            return Some((index, order));\n        }\n\n        let header_ptr = self.market.dynamic.as_ptr().wrapping_add(offset);\n        let header = unsafe { &*(header_ptr as *const RBNodeHeader) };",
+          "endLine": 360,
+          "explanation": "The public iterator creates another typed header reference from the current serialized index.",
+          "id": "e4",
+          "label": "Iterator repeats the unaligned header cast",
+          "language": "rust",
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 349
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "The public safe parsing API creates references to aligned Rust types from arbitrary byte-slice addresses without alignment checks; a caller can pass an unaligned subslice and trigger undefined behavior through safe code."
+      },
+      "extensions": {
+        "candidateId": "candidate-4363db215507e6ef",
+        "ledgerRowId": "candidate-4363db215507e6ef"
+      },
+      "findingId": "csf_f4d63c98a4c87c15e93cd5a4",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:005b2bc4ebed65fec3492b17988414cc0c41fbd3b17fb392c5c755374c642e20"
+      },
+      "identity": {
+        "anchor": "slim-client-byte-slice-casts",
+        "instance": "slim-unaligned-typed-references"
+      },
+      "locations": [
+        {
+          "endLine": 77,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "entrypoint",
+          "startLine": 63
+        },
+        {
+          "endLine": 72,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 70
+        },
+        {
+          "endLine": 251,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 220
+        },
+        {
+          "endLine": 304,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 298
+        },
+        {
+          "endLine": 360,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 349
+        },
+        {
+          "endLine": 400,
+          "path": "client/rust/slim/src/state.rs",
+          "role": "sink",
+          "startLine": 369
+        }
+      ],
+      "occurrenceId": "occ_c76eceddca3597f173f1d5f6",
+      "preventiveControls": [
+        "Require all `unsafe` byte-to-reference casts to document and test size, alignment, and validity preconditions.",
+        "Run Miri against public safe parsing APIs in CI."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Use `bytemuck::try_from_bytes()` only with types that satisfy its validity contracts, copy into aligned owned values where necessary, and return values rather than references into arbitrary byte slices.",
+      "remediationTests": [
+        "Pass every possible one-byte-shifted sufficiently long subslice into the public parser under Miri and assert a defined error or safe copied value.",
+        "Fuzz dynamic node offsets under Miri/address sanitizers and ensure no typed reference is formed without alignment validation."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "summary": "A safe byte-slice parser may create typed references only after proving alignment and validity for each referenced type. The implementation violates that invariant along this validated path: A safe caller passes a sufficiently long but unaligned byte slice to the slim client's parsing API; the implementation casts its pointer and dynamic offsets to aligned Rust types and creates typed references, violating alignment requirements and invoking undefined behavior."
+      },
+      "ruleId": "memory-safety.unaligned-typed-reference",
+      "severity": {
+        "changeConditions": "Raise severity only with a concrete in-scope call path where a lower-privileged attacker controls slice alignment and the UB yields reliable memory corruption or code execution.",
+        "level": "low",
+        "rationale": "The Rust validity violation is exact, yet a realistic remote attacker-controlled alignment path and exploitation beyond local crash/misbehavior are not demonstrated. Low impact and low likelihood map to low severity."
+      },
+      "summary": "The slim client's safe parsing API creates typed references from potentially unaligned byte slices, invoking undefined behavior. The affected boundary is `MarketFixed::try_from_bytes()` and `Market` accessors; the evidenced outcome is undefined behavior with deployment-dependent crash or misbehavior.",
+      "taxonomy": {
+        "category": "Rust memory-safety unsoundness",
+        "cwe": [
+          "CWE-704",
+          "CWE-758"
+        ]
+      },
+      "title": "The slim client's safe parsing API creates typed references from potentially unaligned byte slices, invoking undefined behavior",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC/file/package callers control slice base address and contents",
+          "Exact source-control-sink path: length-only guards precede raw pointer casts to aligned typed references",
+          "Realistic interface/boundary: Market::try_from_bytes and accessors are public slim-client APIs",
+          "Security impact beyond self-only correctness: undefined behavior can crash or corrupt a host process",
+          "Countercontrols/proof gaps: offset length checks do not prove pointer alignment"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "limitations": [
+          "No sanitizer reproduction was attempted because Rust UB need not deterministically crash and the violated alignment precondition is exact.",
+          "Architectures tolerant of unaligned loads do not make creation of misaligned references defined behavior."
+        ],
+        "method": "bounded static safe-API alignment/unsafe-dereference assessment",
+        "observations": [
+          "client/rust/slim/src/state.rs:63-77 casts data.as_ptr() to *const MarketFixed after only a length check.",
+          "Lines 220-251 and 298-304 repeat typed reference casts for orders, seats, and RBNodeHeader.",
+          "Safe callers can construct an unaligned &[u8] subslice without unsafe code."
+        ],
+        "summary": "The public safe parsing API creates references to aligned Rust types from arbitrary byte-slice addresses without alignment checks; a caller can pass an unaligned subslice and trigger undefined behavior through safe code."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1"
+          ],
+          "outcome": "any still-bound Solana identity can be impersonated",
+          "sink": "repository readers and source history",
+          "source": "a tracked Base58 value that decodes to a complete 64-byte Solana secret key",
+          "summary": "Repository readers can obtain the complete committed Solana signing credential from tracked source and can sign as that key if any authority or asset binding remains active."
+        },
+        "evidenceRefs": [
+          "e1"
+        ],
+        "impact": {
+          "level": "unknown",
+          "why": "Exposure of a structurally complete private key is established, while current authority, assets, and liveness are unknown and were not tested. The matrix maps unknown impact and unknown likelihood to low severity; no direct on-chain loss is claimed."
+        },
+        "likelihood": {
+          "level": "unknown",
+          "why": "Exposure of a structurally complete private key is established, while current authority, assets, and liveness are unknown and were not tested. The matrix maps unknown impact and unknown likelihood to low severity; no direct on-chain loss is claimed."
+        },
+        "limitations": [
+          "The repository does not establish that the key is live, funded, or bound to program, mint, upgrade, or operational authority. That is dispositive against claims of current asset theft or privileged control, but not against reporting the complete credential as compromised material."
+        ],
+        "reachability": {
+          "attacker": "any party with current or historical repository read access",
+          "entrypoint": "`scripts/pk-solflare-to-phantom.ts` line 30",
+          "outcome": "any still-bound Solana identity can be impersonated",
+          "preconditions": "The exposed key still controls assets or an authority; current liveness was intentionally not tested.",
+          "summary": "Product surface: repository secret hygiene and any external Solana identity still bound to the committed key. Attacker: any lower-trust party with repository read access. Boundary: secret signing material crosses from an intended private identity into source history; no secret value is reproduced or used in this analysis."
+        },
+        "summary": "Repository readers can obtain the complete committed Solana signing credential from tracked source and can sign as that key if any authority or asset binding remains active."
+      },
+      "codeEvidence": [
+        {
+          "code": "// [REDACTED: committed Base58 Solana secret key]",
+          "endLine": 30,
+          "explanation": "The tracked comment contains a value locally confirmed to decode to the complete Solana secret-key length; the credential is deliberately redacted here.",
+          "id": "e1",
+          "label": "Tracked complete Solana key material",
+          "language": "typescript",
+          "path": "scripts/pk-solflare-to-phantom.ts",
+          "role": "user_input",
+          "startLine": 30
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "A tracked source comment contains one Base58 value that locally decodes to the complete 64-byte Solana secret-key format; repository readers possess the credential material, although current live authority/value is unknown."
+      },
+      "extensions": {
+        "candidateId": "candidate-49372c4c81409ac9",
+        "ledgerRowId": "candidate-49372c4c81409ac9"
+      },
+      "findingId": "csf_c464b1f647e4400ec643c8c8",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:bb712089c3fa395a699c28f164017a5177431ffeaba4870c65d9e78654ffb9ab"
+      },
+      "identity": {
+        "anchor": "private-key-conversion-script-comment",
+        "instance": "committed-solana-secret-key"
+      },
+      "locations": [
+        {
+          "endLine": 30,
+          "path": "scripts/pk-solflare-to-phantom.ts",
+          "role": "source",
+          "startLine": 30
+        }
+      ],
+      "occurrenceId": "occ_6c44e2f023d7b1b7c8d5fcb2",
+      "preventiveControls": [
+        "Install pre-commit and CI secret scanning with Solana 64-byte key format detection.",
+        "Use hardware-backed or managed signing and documented emergency rotation procedures."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Immediately treat the key as compromised: rotate every asset, program, mint, upgrade, or operational authority it ever held; remove it from the working tree and, after rotation, purge history according to the repository's incident process.",
+      "remediationTests": [
+        "Run a secret scanner across the full Git history and assert no complete Solana key encodings remain.",
+        "Using only public-key/authority data, verify the retired public key no longer controls assets or privileged authorities; never use the exposed secret for validation."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1"
+        ],
+        "summary": "Complete signing material must never be committed to source or its history, including comments. The implementation violates that invariant along this validated path: Repository readers can obtain the complete committed Solana signing credential from tracked source and can sign as that key if any authority or asset binding remains active."
+      },
+      "ruleId": "hardcoded-credentials.solana-private-key",
+      "severity": {
+        "changeConditions": "Raise severity only if non-secret public evidence proves the key currently controls valuable assets, program authority, mint authority, or another live privileged identity; rotate it without using or reproducing the committed secret.",
+        "level": "low",
+        "rationale": "Exposure of a structurally complete private key is established, while current authority, assets, and liveness are unknown and were not tested. The matrix maps unknown impact and unknown likelihood to low severity; no direct on-chain loss is claimed."
+      },
+      "summary": "A complete Solana private key is committed in a source comment. The affected boundary is `scripts/pk-solflare-to-phantom.ts` line 30; the evidenced outcome is any still-bound Solana identity can be impersonated.",
+      "taxonomy": {
+        "category": "Hardcoded credential / private-key disclosure",
+        "cwe": [
+          "CWE-798"
+        ]
+      },
+      "title": "A complete Solana private key is committed in a source comment",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: any repository reader can access the committed secret material",
+          "Exact source-control-sink path: the tracked value decodes to a complete Solana secret-key byte length",
+          "Realistic interface/boundary: source control is a concrete disclosure boundary",
+          "Security impact beyond self-only correctness: reuse could authorize signatures outside the repository",
+          "Countercontrols/proof gaps: unknown live authority limits impact but does not undo credential exposure"
+        ],
+        "evidenceRefs": [
+          "e1"
+        ],
+        "limitations": [
+          "Whether the key is revoked, disposable, or currently controls funds/program authority is unknown.",
+          "Treat it as compromised and rotate any authority it has ever held."
+        ],
+        "method": "safe local format/presence check without secret reproduction",
+        "observations": [
+          "scripts/pk-solflare-to-phantom.ts is tracked and contains one Base58 candidate on line 30.",
+          "A local non-network check reported exactly one candidate decoding to 64 bytes; the value was not printed, copied, or written.",
+          "No network or chain query was made to test balances, authorities, or liveness."
+        ],
+        "summary": "A tracked source comment contains one Base58 value that locally decodes to the complete 64-byte Solana secret-key format; repository readers possess the credential material, although current live authority/value is unknown."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2"
+          ],
+          "outcome": "repository readers can reuse any still-active provider quota or billing allowance",
+          "sink": "`new Connection(FALLBACK_RPC_URL)`",
+          "source": "the hardcoded fallback Shyft RPC URL query credential",
+          "summary": "A repository reader copies the embedded fallback RPC API credential from the tracked URL and, if it remains valid, sends requests that consume the associated provider quota or billing allowance; the backfill script actively constructs a Connection from that URL on fallback."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "Potential abuse is limited to uncertain RPC quota or billing and the credential may already be revoked. Low impact maps to low severity with unknown likelihood."
+        },
+        "likelihood": {
+          "level": "unknown",
+          "why": "Potential abuse is limited to uncertain RPC quota or billing and the credential may already be revoked. Low impact maps to low severity with unknown likelihood."
+        },
+        "limitations": [
+          "Current validity, provider plan, allowed methods, rate limits, and billing exposure are unknown. That prevents claims of privileged RPC access or material cost, but the active secret-bearing fallback path remains evidenced."
+        ],
+        "reachability": {
+          "attacker": "any party with repository read access",
+          "entrypoint": "fallback setup in `backfill-tickers.ts`",
+          "outcome": "repository readers can reuse any still-active provider quota or billing allowance",
+          "preconditions": "The exposed provider key remains active and has meaningful quota or billing scope.",
+          "summary": "Product surface: operator RPC access for the backfill script. Attacker: any party with repository read access. Boundary: a provider credential is distributed in source rather than a secret store; this analysis neither prints nor uses it."
+        },
+        "summary": "A repository reader copies the embedded fallback RPC API credential from the tracked URL and, if it remains valid, sends requests that consume the associated provider quota or billing allowance; the backfill script actively constructs a Connection from that URL on fallback."
+      },
+      "codeEvidence": [
+        {
+          "code": "const FALLBACK_RPC_URL = 'https://rpc.shyft.to?api_key=[REDACTED]';",
+          "endLine": 8,
+          "explanation": "The fallback endpoint is tracked with an `api_key` query value; the value is redacted in this artifact.",
+          "id": "e1",
+          "label": "Fallback RPC URL embeds a provider credential",
+          "language": "typescript",
+          "path": "scripts/backfill-tickers.ts",
+          "role": "user_input",
+          "startLine": 8
+        },
+        {
+          "code": "    connection = new Connection(FALLBACK_RPC_URL, 'confirmed');",
+          "endLine": 124,
+          "explanation": "The error path constructs a live Solana `Connection` from the hardcoded fallback URL.",
+          "id": "e2",
+          "label": "Fallback credential is used after primary failure",
+          "language": "typescript",
+          "path": "scripts/backfill-tickers.ts",
+          "role": "sink",
+          "startLine": 124
+        }
+      ],
+      "confidence": {
+        "level": "medium",
+        "rationale": "A tracked fallback Shyft URL embeds an API credential and the error path constructs a live RPC Connection from it; repository readers can reuse any still-active quota, though revocation and account scope are unknown."
+      },
+      "extensions": {
+        "candidateId": "candidate-716841d087c6d97e",
+        "ledgerRowId": "candidate-716841d087c6d97e"
+      },
+      "findingId": "csf_46abd63ca357aeed260d3203",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:7b6794d1f779642a641305b542e5fe082de61938941ab2dd5ec1b7e36679dba6"
+      },
+      "identity": {
+        "anchor": "backfill-tickers-rpc-credentials",
+        "instance": "hardcoded-shyft-fallback-rpc-key"
+      },
+      "locations": [
+        {
+          "endLine": 8,
+          "path": "scripts/backfill-tickers.ts",
+          "role": "source",
+          "startLine": 8
+        },
+        {
+          "endLine": 124,
+          "path": "scripts/backfill-tickers.ts",
+          "role": "sink",
+          "startLine": 124
+        }
+      ],
+      "occurrenceId": "occ_de6f30709e28bc5d62e24b24",
+      "preventiveControls": [
+        "Enable provider-side key restrictions, quotas, and usage alerts.",
+        "Block secret-bearing URL query parameters in pre-commit and CI scanning."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Revoke and rotate the fallback key, remove it from source/history, inject the fallback URL from a secret store or environment, and fail with a clear operator error when it is absent.",
+      "remediationTests": [
+        "Start the script without the fallback secret and assert it fails closed without embedding a default credential.",
+        "Run history-wide secret scanning and assert the retired key and equivalent provider URL patterns are absent."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "summary": "Provider credentials must come from a secret manager or environment and must not be distributed in tracked source. The implementation violates that invariant along this validated path: A repository reader copies the embedded fallback RPC API credential from the tracked URL and, if it remains valid, sends requests that consume the associated provider quota or billing allowance; the backfill script actively constructs a Connection from that URL on fallback."
+      },
+      "ruleId": "hardcoded-credentials.provider-api-key",
+      "severity": {
+        "changeConditions": "Raise impact only if the credential is proven active with meaningful paid quota or privileged methods; remove and rotate it without making validation requests with the exposed key.",
+        "level": "low",
+        "rationale": "Potential abuse is limited to uncertain RPC quota or billing and the credential may already be revoked. Low impact maps to low severity with unknown likelihood."
+      },
+      "summary": "A fallback Shyft RPC API credential is hardcoded and actively used by the backfill script. The affected boundary is fallback setup in `backfill-tickers.ts`; the evidenced outcome is repository readers can reuse any still-active provider quota or billing allowance.",
+      "taxonomy": {
+        "category": "Hardcoded API credential",
+        "cwe": [
+          "CWE-798"
+        ]
+      },
+      "title": "A fallback Shyft RPC API credential is hardcoded and actively used by the backfill script",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: repository readers control copies of the embedded credential",
+          "Exact source-control-sink path: the fallback string flows into Connection after primary failure",
+          "Realistic interface/boundary: the third-party RPC API is a concrete credential boundary",
+          "Security impact beyond self-only correctness: reuse can consume project quota or incur service impact",
+          "Countercontrols/proof gaps: possible revocation limits current impact but is not proven"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "limitations": [
+          "Current validity, billing plan, rate limits, and allowed methods are unknown.",
+          "Remove the fallback credential from source and rotate it."
+        ],
+        "method": "safe local credential-presence/use trace without network calls",
+        "observations": [
+          "A non-secret-bearing count found two tracked api_key URL lines in scripts/backfill-tickers.ts.",
+          "scripts/backfill-tickers.ts:124 constructs a Connection with the fallback URL.",
+          "No request was made with the credential and its value was not reproduced."
+        ],
+        "summary": "A tracked fallback Shyft URL embeds an API credential and the error path constructs a live RPC Connection from it; repository readers can reuse any still-active quota, though revocation and account scope are unknown."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2"
+          ],
+          "outcome": "repository readers can reuse any still-active provider quota or billing allowance",
+          "sink": "`new Connection(PRIMARY_RPC_URL)`",
+          "source": "the hardcoded primary Shyft RPC URL query credential",
+          "summary": "A repository reader copies the embedded primary RPC API credential from the tracked URL and, if it remains valid, sends requests that consume the associated provider quota or billing allowance; the backfill script constructs its primary Connection directly from that URL."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "Potential harm is uncertain quota or billing consumption rather than demonstrated privileged compromise, and the key may be revoked. Low impact maps to low severity with unknown likelihood."
+        },
+        "likelihood": {
+          "level": "unknown",
+          "why": "Potential harm is uncertain quota or billing consumption rather than demonstrated privileged compromise, and the key may be revoked. Low impact maps to low severity with unknown likelihood."
+        },
+        "limitations": [
+          "Current validity, provider plan, allowed methods, rate limits, and billing exposure are unknown. That prevents claims of privileged access or significant cost, but does not remove the tracked active-use credential."
+        ],
+        "reachability": {
+          "attacker": "any party with repository read access",
+          "entrypoint": "primary setup in `backfill-tickers.ts`",
+          "outcome": "repository readers can reuse any still-active provider quota or billing allowance",
+          "preconditions": "The exposed provider key remains active and has meaningful quota or billing scope.",
+          "summary": "Product surface: operator RPC access for the backfill script. Attacker: any party with repository read access. Boundary: a provider credential is distributed in source rather than a secret store; this analysis neither prints nor uses it."
+        },
+        "summary": "A repository reader copies the embedded primary RPC API credential from the tracked URL and, if it remains valid, sends requests that consume the associated provider quota or billing allowance; the backfill script constructs its primary Connection directly from that URL."
+      },
+      "codeEvidence": [
+        {
+          "code": "const PRIMARY_RPC_URL = 'https://rpc.shyft.to?api_key=[REDACTED]';",
+          "endLine": 7,
+          "explanation": "The primary endpoint is tracked with an `api_key` query value; the value is redacted in this artifact.",
+          "id": "e1",
+          "label": "Primary RPC URL embeds a provider credential",
+          "language": "typescript",
+          "path": "scripts/backfill-tickers.ts",
+          "role": "user_input",
+          "startLine": 7
+        },
+        {
+          "code": "  let connection = new Connection(PRIMARY_RPC_URL, 'confirmed');",
+          "endLine": 116,
+          "explanation": "The main path constructs the Solana `Connection` directly from the hardcoded primary URL.",
+          "id": "e2",
+          "label": "Primary credential initializes the live connection",
+          "language": "typescript",
+          "path": "scripts/backfill-tickers.ts",
+          "role": "sink",
+          "startLine": 116
+        }
+      ],
+      "confidence": {
+        "level": "medium",
+        "rationale": "A tracked primary Shyft URL embeds an API credential and is directly used to create the script's main RPC Connection; any still-active quota is available to repository readers."
+      },
+      "extensions": {
+        "candidateId": "candidate-afe528af52e7cce6",
+        "ledgerRowId": "candidate-afe528af52e7cce6"
+      },
+      "findingId": "csf_2c45e3df869f82372f50d494",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:8ecaa8350ac88025cdc60eeb92a2c95ca4057f2d09ccdeb8dd1f4b8632a25622"
+      },
+      "identity": {
+        "anchor": "backfill-tickers-rpc-credentials",
+        "instance": "hardcoded-shyft-primary-rpc-key"
+      },
+      "locations": [
+        {
+          "endLine": 7,
+          "path": "scripts/backfill-tickers.ts",
+          "role": "source",
+          "startLine": 7
+        },
+        {
+          "endLine": 116,
+          "path": "scripts/backfill-tickers.ts",
+          "role": "sink",
+          "startLine": 116
+        }
+      ],
+      "occurrenceId": "occ_2bac4db97b8d6188a9465140",
+      "preventiveControls": [
+        "Enable provider-side key restrictions, quotas, and usage alerts.",
+        "Block secret-bearing URL query parameters in pre-commit and CI scanning."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Revoke and rotate the primary key, remove it from source/history, require the primary RPC URL from a secret store or environment, and use a separately scoped fallback credential.",
+      "remediationTests": [
+        "Start the script without the primary secret and assert it fails closed before constructing a connection.",
+        "Run history-wide secret scanning and assert the retired key and equivalent provider URL patterns are absent."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "summary": "Provider credentials must come from a secret manager or environment and must not be distributed in tracked source. The implementation violates that invariant along this validated path: A repository reader copies the embedded primary RPC API credential from the tracked URL and, if it remains valid, sends requests that consume the associated provider quota or billing allowance; the backfill script constructs its primary Connection directly from that URL."
+      },
+      "ruleId": "hardcoded-credentials.provider-api-key",
+      "severity": {
+        "changeConditions": "Raise impact only if the credential is proven active with meaningful paid quota or privileged methods; remove and rotate it without issuing requests with the exposed key.",
+        "level": "low",
+        "rationale": "Potential harm is uncertain quota or billing consumption rather than demonstrated privileged compromise, and the key may be revoked. Low impact maps to low severity with unknown likelihood."
+      },
+      "summary": "A primary Shyft RPC API credential is hardcoded and actively used by the backfill script. The affected boundary is primary setup in `backfill-tickers.ts`; the evidenced outcome is repository readers can reuse any still-active provider quota or billing allowance.",
+      "taxonomy": {
+        "category": "Hardcoded API credential",
+        "cwe": [
+          "CWE-798"
+        ]
+      },
+      "title": "A primary Shyft RPC API credential is hardcoded and actively used by the backfill script",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: repository readers can copy the embedded credential",
+          "Exact source-control-sink path: the primary URL flows into a live Connection constructor",
+          "Realistic interface/boundary: the third-party RPC API is a concrete secret/quota boundary",
+          "Security impact beyond self-only correctness: reuse can consume quota or create account/service cost",
+          "Countercontrols/proof gaps: possible revocation is an unresolved runtime fact"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2"
+        ],
+        "limitations": [
+          "The key's current validity, privileges, and billing exposure are unknown.",
+          "Rotate it and load it from a secret store/environment."
+        ],
+        "method": "safe local credential-presence/use trace without network calls",
+        "observations": [
+          "A safe count confirmed the tracked file contains the primary and fallback api_key URL lines without printing them.",
+          "scripts/backfill-tickers.ts:116 constructs the primary Connection from the hardcoded URL.",
+          "No network call was made with either key."
+        ],
+        "summary": "A tracked primary Shyft URL embeds an API credential and is directly used to create the script's main RPC Connection; any still-active quota is available to repository readers."
+      }
+    },
+    {
+      "attackPath": {
+        "dataflow": {
+          "evidenceRefs": [
+            "e1",
+            "e2",
+            "e3",
+            "e4"
+          ],
+          "outcome": "a safe reference containing an invalid Rust enum and resulting undefined behavior",
+          "sink": "`bytemuck::from_bytes()` through the false manual `Pod` implementation",
+          "source": "hostile RPC bytes controlling an `RBNode` color byte",
+          "summary": "A hostile configured RPC returns market bytes whose RBNode color byte is outside the two valid enum discriminants; the OKX metadata path reaches bytemuck::from_bytes through a false manual Pod implementation and creates a safe reference containing an invalid Rust enum, invoking undefined behavior."
+        },
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "impact": {
+          "level": "low",
+          "why": "The Rust validity violation is exact, but exploitation requires hostile provider bytes and no reliable memory-corruption consequence beyond local parser failure is shown. Low impact and low likelihood map to low severity."
+        },
+        "likelihood": {
+          "level": "low",
+          "why": "The Rust validity violation is exact, but exploitation requires hostile provider bytes and no reliable memory-corruption consequence beyond local parser failure is shown. Low impact and low likelihood map to low severity."
+        },
+        "limitations": [
+          "Canonical Manifest-owned accounts should contain only colors written by the tree implementation, and the UB may not visibly fail on a given build. That lowers ordinary likelihood and impact but does not make invalid hostile RPC bytes safe."
+        ],
+        "reachability": {
+          "attacker": "a malicious configured RPC endpoint or response-tampering actor",
+          "entrypoint": "OKX market metadata decoding",
+          "outcome": "a safe reference containing an invalid Rust enum and resulting undefined behavior",
+          "preconditions": "Hostile bytes reach the shared decoder with a color byte other than zero or one.",
+          "summary": "Product surface: the OKX off-chain market parser using the shared hypertree library. Attacker: a malicious configured RPC or actor able to tamper with account responses. Boundary: remote bytes enter a purportedly safe typed decoder; the shown result is parser UB with deployment-dependent crash/misbehavior, not demonstrated code execution or on-chain mutation."
+        },
+        "summary": "A hostile configured RPC returns market bytes whose RBNode color byte is outside the two valid enum discriminants; the OKX metadata path reaches bytemuck::from_bytes through a false manual Pod implementation and creates a safe reference containing an invalid Rust enum, invoking undefined behavior."
+      },
+      "codeEvidence": [
+        {
+          "code": "    fn fetch_pool_metadata(&self, client: &RpcClient, pool_address: &str) -> Option<PoolMetadata> {\n        let market_data = client\n            .get_account_data(&Pubkey::from_str(pool_address).ok()?)\n            .ok()?;\n        let market: MarketValue =\n            manifest::program::get_dynamic_value_or(market_data.as_slice()).ok()?;",
+          "endLine": 127,
+          "explanation": "The configured RPC controls the raw bytes later interpreted as red-black-tree nodes.",
+          "id": "e1",
+          "label": "RPC bytes enter typed market decoding",
+          "language": "rust",
+          "path": "client/okx/src/mfx.rs",
+          "role": "user_input",
+          "startLine": 122
+        },
+        {
+          "code": "#[cfg(not(feature = \"certora\"))]\n#[repr(u8)]\n#[derive(Debug, Copy, Clone, PartialEq, Default)]\npub(crate) enum Color {\n    #[default]\n    Black = 0,\n    Red = 1,\n}",
+          "endLine": 935,
+          "explanation": "The `repr(u8)` enum accepts only discriminants 0 and 1, so arbitrary bytes are not valid `Color` values.",
+          "id": "e2",
+          "label": "Color has only two valid bit patterns",
+          "language": "rust",
+          "path": "lib/src/red_black_tree.rs",
+          "role": "expected_control",
+          "startLine": 928
+        },
+        {
+          "code": "#[cfg(not(feature = \"certora\"))]\n#[derive(Debug, Default, Copy, Clone, Zeroable)]\n#[repr(C)]\n/// Node in a RedBlack tree. The first 16 bytes are used for maintaining the\n/// RedBlack and BST properties, the rest is the payload.\npub struct RBNode<V> {\n    pub(crate) left: DataIndex,\n    pub(crate) right: DataIndex,\n    pub(crate) parent: DataIndex,\n    pub(crate) color: Color,\n\n    // Optional enum controlled by the application to identify the type of node.\n    // Defaults to zero.\n    pub(crate) payload_type: u8,\n\n    pub(crate) _unused_padding: u16,\n    pub(crate) value: V,\n}\nunsafe impl<V: Payload> Pod for RBNode<V> {}",
+          "endLine": 989,
+          "explanation": "The node embeds `Color` and then promises that every bit pattern is valid through a manual `Pod` implementation.",
+          "id": "e3",
+          "label": "RBNode containing Color is manually marked Pod",
+          "language": "rust",
+          "path": "lib/src/red_black_tree.rs",
+          "role": "root_control",
+          "startLine": 971
+        },
+        {
+          "code": "pub fn get_helper<T: Get>(data: &[u8], index: DataIndex) -> &T {\n    let index_usize: usize = index as usize;\n    bytemuck::from_bytes(&data[index_usize..index_usize + size_of::<T>()])\n}",
+          "endLine": 13,
+          "explanation": "`get_helper()` uses `bytemuck::from_bytes()` under that false contract, creating a reference containing attacker-controlled invalid enum bits.",
+          "id": "e4",
+          "label": "Bytemuck creates the typed reference",
+          "language": "rust",
+          "path": "lib/src/utils.rs",
+          "role": "sink",
+          "startLine": 10
+        }
+      ],
+      "confidence": {
+        "level": "high",
+        "rationale": "RBNode manually promises Pod even though it contains a repr(u8) enum with only two valid discriminants; hostile RPC bytes can create an invalid Color inside a safe Rust reference, violating language validity and enabling undefined behavior."
+      },
+      "extensions": {
+        "candidateId": "candidate-fbf802b10d31345f",
+        "ledgerRowId": "candidate-fbf802b10d31345f"
+      },
+      "findingId": "csf_e9505ce1a84efe452ad05e73",
+      "fingerprints": {
+        "algorithm": "codex-security/v1",
+        "primary": "codex-security/v1:sha256:3a8c8f401b0c56240ec283797fcf2485e7512e51733be69a344ec094a2e279d4"
+      },
+      "identity": {
+        "anchor": "red-black-tree-node-pod-contract",
+        "instance": "invalid-rbnode-color"
+      },
+      "locations": [
+        {
+          "endLine": 935,
+          "path": "lib/src/red_black_tree.rs",
+          "role": "root_control",
+          "startLine": 920
+        },
+        {
+          "endLine": 168,
+          "path": "client/okx/src/mfx.rs",
+          "role": "entrypoint/wrapper",
+          "startLine": 151
+        },
+        {
+          "endLine": 127,
+          "path": "client/okx/src/mfx.rs",
+          "role": "source",
+          "startLine": 122
+        },
+        {
+          "endLine": 989,
+          "path": "lib/src/red_black_tree.rs",
+          "role": "sink",
+          "startLine": 953
+        },
+        {
+          "endLine": 13,
+          "path": "lib/src/utils.rs",
+          "role": "concrete_implementation",
+          "startLine": 10
+        }
+      ],
+      "occurrenceId": "occ_70b90e4e6c309546aa5dc8b5",
+      "preventiveControls": [
+        "Prohibit manual `Pod` implementations for structs containing Rust enums.",
+        "Use compile-time checked wire types plus explicit validated domain conversion."
+      ],
+      "provenance": {
+        "source": "codex-security-plugin"
+      },
+      "remediation": "Store color as `u8` in the POD wire type and validate/convert it to `Color` after decoding, or remove `Pod` and use a fallible parser that checks every enum discriminant.",
+      "remediationTests": [
+        "Decode all 256 possible color bytes and assert only 0 and 1 produce a `Color`; every other value must return an error without UB.",
+        "Run the hostile-byte decoder corpus under Miri and sanitizers with no manual invalid-enum reference creation."
+      ],
+      "rootCause": {
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "summary": "A type marked `Pod` must permit every possible bit pattern; an enum with only two valid discriminants cannot satisfy that contract. The implementation violates that invariant along this validated path: A hostile configured RPC returns market bytes whose RBNode color byte is outside the two valid enum discriminants; the OKX metadata path reaches bytemuck::from_bytes through a false manual Pod implementation and creates a safe reference containing an invalid Rust enum, invoking undefined behavior."
+      },
+      "ruleId": "memory-safety.invalid-enum-bytes",
+      "severity": {
+        "changeConditions": "Raise severity only with a concrete broadly reachable hostile-byte path and proof of reliable memory corruption, code execution, or sustained shared compromise.",
+        "level": "low",
+        "rationale": "The Rust validity violation is exact, but exploitation requires hostile provider bytes and no reliable memory-corruption consequence beyond local parser failure is shown. Low impact and low likelihood map to low severity."
+      },
+      "summary": "RBNode's manual Pod implementation permits invalid Color discriminants to enter safe Rust references. The affected boundary is OKX market metadata decoding; the evidenced outcome is a safe reference containing an invalid Rust enum and resulting undefined behavior.",
+      "taxonomy": {
+        "category": "Invalid enum construction / Rust undefined behavior",
+        "cwe": [
+          "CWE-843"
+        ]
+      },
+      "title": "RBNode's manual Pod implementation permits invalid Color discriminants to enter safe Rust references",
+      "validation": {
+        "assertions": [
+          "Attacker/source control: RPC account bytes control the color byte",
+          "Exact source-control-sink path: get_helper/bytemuck accepts all bytes because of the manual Pod impl",
+          "Realistic interface/boundary: the OKX RPC metadata path is a concrete safe parsing boundary",
+          "Security impact beyond self-only correctness: invalid enum references create host-process memory-safety/UB impact",
+          "Countercontrols/proof gaps: canonical program writes do not authenticate bytes returned by a hostile RPC"
+        ],
+        "evidenceRefs": [
+          "e1",
+          "e2",
+          "e3",
+          "e4"
+        ],
+        "limitations": [
+          "UB may not reproduce as a deterministic crash on a given compiler/architecture.",
+          "The violated bytemuck/Rust validity invariant is exact despite runtime variability."
+        ],
+        "method": "bounded static byte-validity/unsafe-trait assessment",
+        "observations": [
+          "lib/src/red_black_tree.rs:928-935 defines Color with only 0 and 1 valid.",
+          "lib/src/red_black_tree.rs:971-990 embeds Color in RBNode and manually implements Pod.",
+          "client/okx/src/mfx.rs:122-168 parses RPC bytes and iterates RBNode values through get_helper."
+        ],
+        "summary": "RBNode manually promises Pod even though it contains a repr(u8) enum with only two valid discriminants; hostile RPC bytes can create an invalid Color inside a safe Rust reference, violating language validity and enabling undefined behavior."
+      }
+    }
+  ],
+  "scanId": "05b2d302-7473-4306-ac85-0869f3d5d1ec",
+  "schemaVersion": "1.0"
+}

--- a/client/okx/src/mfx.rs
+++ b/client/okx/src/mfx.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use hypertree::hypertree::HyperTreeValueIteratorTrait;
+use hypertree::{
+    hypertree::{HyperTreeReadOperations, HyperTreeValueIteratorTrait},
+    validate_red_black_tree,
+};
 use log::error;
 use manifest::{
     quantities::WrapperU64,
@@ -43,10 +46,28 @@ impl Dex for Manifest {
             get_extra!(metadata, "base_decimals", PoolMetadataValue::Number).unwrap_or(6.0_f64);
         let quote_decimals =
             get_extra!(metadata, "quote_decimals", PoolMetadataValue::Number).unwrap_or(6.0_f64);
+        // Metadata is untrusted: bound exponents before integer pow and reject
+        // NaN/fractional values that would otherwise truncate during casting.
+        let decimal_scale = |decimals: f64| -> Option<f64> {
+            if !decimals.is_finite() || decimals.fract() != 0.0 || !(0.0..=19.0).contains(&decimals)
+            {
+                return None;
+            }
+            Some(10_u64.checked_pow(decimals as u32)? as f64)
+        };
+        let Some(base_scale) = decimal_scale(base_decimals) else {
+            return 0.0;
+        };
+        let Some(quote_scale) = decimal_scale(quote_decimals) else {
+            return 0.0;
+        };
 
         for ask in asks {
             match ask {
                 PoolMetadataValue::Array(ask) => {
+                    if ask.len() < 2 {
+                        continue;
+                    }
                     let base_atoms = match ask[0] {
                         PoolMetadataValue::Number(base_atoms) => base_atoms,
                         _ => 0.0_f64,
@@ -55,10 +76,15 @@ impl Dex for Manifest {
                         PoolMetadataValue::Number(base_atoms) => base_atoms,
                         _ => 0.0_f64,
                     };
-                    let base_tokens: f64 =
-                        (base_atoms as f64) / (10_u64.pow(base_decimals as u32) as f64);
-                    let quote_tokens: f64 =
-                        (quote_atoms as f64) / (10_u64.pow(quote_decimals as u32) as f64);
+                    let base_tokens = base_atoms / base_scale;
+                    let quote_tokens = quote_atoms / quote_scale;
+                    if !base_tokens.is_finite()
+                        || !quote_tokens.is_finite()
+                        || base_tokens <= 0.0
+                        || quote_tokens < 0.0
+                    {
+                        continue;
+                    }
 
                     if base_tokens < remaining_in {
                         total_out += remaining_in / base_tokens * quote_tokens;
@@ -125,6 +151,21 @@ impl Dex for Manifest {
             .ok()?;
         let market: MarketValue =
             manifest::program::get_dynamic_value_or(market_data.as_slice()).ok()?;
+        let bids = market.get_bids();
+        let asks = market.get_asks();
+        // Validate RPC-sourced links before the zero-copy iterator follows them.
+        validate_red_black_tree::<RestingOrder>(
+            &market.dynamic,
+            bids.get_root_index(),
+            bids.get_max_index(),
+        )
+        .ok()?;
+        validate_red_black_tree::<RestingOrder>(
+            &market.dynamic,
+            asks.get_root_index(),
+            asks.get_max_index(),
+        )
+        .ok()?;
         let base_vault: &Pubkey = market.fixed.get_base_vault();
         let quote_vault: &Pubkey = market.fixed.get_quote_vault();
 
@@ -150,8 +191,7 @@ impl Dex for Manifest {
 
         // Bids is an array of arrays. Top of book is first. Similar for asks.
         // [ [baseAtoms1, quoteAtoms1], [baseAtoms2, quoteAtoms2], [baseAtoms3, quoteAtoms3], ...]
-        let bids_vec: Vec<PoolMetadataValue> = market
-            .get_bids()
+        let bids_vec: Vec<PoolMetadataValue> = bids
             .iter::<RestingOrder>()
             .map(|(_ind, resting_order)| {
                 let bid = resting_order;
@@ -160,7 +200,7 @@ impl Dex for Manifest {
                     PoolMetadataValue::Number(
                         bid.get_price()
                             .checked_quote_for_base(bid.get_num_base_atoms(), true)
-                            .unwrap()
+                            .unwrap_or_default()
                             .as_u64() as f64,
                     ),
                 ])
@@ -168,8 +208,7 @@ impl Dex for Manifest {
             .collect::<Vec<PoolMetadataValue>>();
         extra.insert("bids".to_string(), PoolMetadataValue::Array(bids_vec));
 
-        let asks_vec: Vec<PoolMetadataValue> = market
-            .get_asks()
+        let asks_vec: Vec<PoolMetadataValue> = asks
             .iter::<RestingOrder>()
             .map(|(_ind, resting_order)| {
                 let ask = resting_order;
@@ -178,7 +217,7 @@ impl Dex for Manifest {
                     PoolMetadataValue::Number(
                         ask.get_price()
                             .checked_quote_for_base(ask.get_num_base_atoms(), true)
-                            .unwrap()
+                            .unwrap_or_default()
                             .as_u64() as f64,
                     ),
                 ])

--- a/client/rust/jup/src/lib.rs
+++ b/client/rust/jup/src/lib.rs
@@ -98,6 +98,11 @@ impl Amm for ManifestMarket {
     }
 
     fn from_keyed_account(keyed_account: &KeyedAccount, _amm_context: &AmmContext) -> Result<Self> {
+        // Jupiter supplies account bytes from RPC; reject truncation before
+        // split_at/get_helper can panic while refreshing routes.
+        if keyed_account.account.data.len() < size_of::<MarketFixed>() {
+            anyhow::bail!("market account data is truncated");
+        }
         let mut_data: &mut &[u8] = &mut keyed_account.account.data.as_slice();
 
         let (header_bytes, dynamic_data) = mut_data.split_at(size_of::<MarketFixed>());
@@ -119,6 +124,8 @@ impl Amm for ManifestMarket {
     }
 
     fn update(&mut self, account_map: &AccountMap) -> Result<()> {
+        // Every optional RPC account is independently untrusted and may be
+        // absent or truncated during a slot transition.
         if let Some(mint) = account_map.get(&self.get_base_mint()) {
             self.base_token_program = mint.owner;
         };
@@ -126,6 +133,9 @@ impl Amm for ManifestMarket {
             self.quote_token_program = mint.owner;
         };
         if let Some(global) = account_map.get(&self.get_quote_global_address()) {
+            if global.data.len() < size_of::<GlobalFixed>() {
+                anyhow::bail!("quote global account data is truncated");
+            }
             let (header_bytes, dynamic_data) = global.data.split_at(size_of::<GlobalFixed>());
             let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(header_bytes, 0_u32);
             self.quote_global = Some(DynamicAccount::<GlobalFixed, Vec<u8>> {
@@ -134,6 +144,9 @@ impl Amm for ManifestMarket {
             });
         };
         if let Some(global) = account_map.get(&self.get_base_global_address()) {
+            if global.data.len() < size_of::<GlobalFixed>() {
+                anyhow::bail!("base global account data is truncated");
+            }
             let (header_bytes, dynamic_data) = global.data.split_at(size_of::<GlobalFixed>());
             let global_fixed: &GlobalFixed = get_helper::<GlobalFixed>(header_bytes, 0_u32);
             self.base_global = Some(DynamicAccount::<GlobalFixed, Vec<u8>> {
@@ -142,7 +155,12 @@ impl Amm for ManifestMarket {
             });
         };
 
-        let market_account: &solana_account::Account = account_map.get(&self.key).unwrap();
+        let market_account: &solana_account::Account = account_map
+            .get(&self.key)
+            .ok_or_else(|| anyhow::anyhow!("market account missing from update"))?;
+        if market_account.data.len() < size_of::<MarketFixed>() {
+            anyhow::bail!("market account data is truncated");
+        }
 
         let (header_bytes, dynamic_data) = market_account.data.split_at(size_of::<MarketFixed>());
         let market_fixed: &MarketFixed = get_helper::<MarketFixed>(header_bytes, 0_u32);

--- a/client/rust/slim/src/state.rs
+++ b/client/rust/slim/src/state.rs
@@ -6,6 +6,7 @@ use crate::constants::{
 };
 use hypertree::{DataIndex, NIL, RBTREE_OVERHEAD_BYTES};
 use solana_pubkey::Pubkey;
+use std::collections::HashSet;
 
 /// The fixed header of a market account.
 #[derive(Debug, Clone, Copy)]
@@ -62,13 +63,14 @@ pub struct MarketFixed {
 
 impl MarketFixed {
     /// Parse a MarketFixed from bytes.
-    pub fn try_from_bytes(data: &[u8]) -> Option<&Self> {
+    pub fn try_from_bytes(data: &[u8]) -> Option<Self> {
         if data.len() < MARKET_FIXED_SIZE {
             return None;
         }
 
-        // Safety: We've verified the length is sufficient
-        let fixed = unsafe { &*(data.as_ptr() as *const MarketFixed) };
+        // All fields accept every bit pattern; read_unaligned avoids requiring
+        // RPC-provided byte buffers to satisfy MarketFixed's alignment.
+        let fixed = unsafe { data.as_ptr().cast::<MarketFixed>().read_unaligned() };
 
         if fixed.discriminant != MARKET_FIXED_DISCRIMINANT {
             return None;
@@ -188,13 +190,15 @@ pub struct RBNodeHeader {
     pub left: DataIndex,
     pub right: DataIndex,
     pub parent: DataIndex,
-    pub color: u32, // 0 = black, 1 = red
+    pub color: u8, // 0 = black, 1 = red
+    pub payload_type: u8,
+    pub _padding: u16,
 }
 
 /// Full market state including dynamic data.
 pub struct Market<'a> {
     /// The fixed header.
-    pub fixed: &'a MarketFixed,
+    pub fixed: MarketFixed,
     /// The dynamic data (orders, seats, free list).
     pub dynamic: &'a [u8],
 }
@@ -204,7 +208,11 @@ impl<'a> Market<'a> {
     pub fn try_from_bytes(data: &'a [u8]) -> Option<Self> {
         let fixed = MarketFixed::try_from_bytes(data)?;
         let dynamic = &data[MARKET_FIXED_SIZE..];
-        Some(Self { fixed, dynamic })
+        let market = Self { fixed, dynamic };
+        market.validate_tree(market.fixed.bids_root_index, RESTING_ORDER_SIZE)?;
+        market.validate_tree(market.fixed.asks_root_index, RESTING_ORDER_SIZE)?;
+        market.validate_tree(market.fixed.claimed_seats_root_index, CLAIMED_SEAT_SIZE)?;
+        Some(market)
     }
 
     /// Get the base mint.
@@ -218,37 +226,13 @@ impl<'a> Market<'a> {
     }
 
     /// Get a resting order at the given index.
-    pub fn get_order(&self, index: DataIndex) -> Option<&RestingOrder> {
-        if index == NIL {
-            return None;
-        }
-        let offset = index as usize;
-        if offset + RBTREE_OVERHEAD_BYTES + RESTING_ORDER_SIZE > self.dynamic.len() {
-            return None;
-        }
-        // Skip the RBNode header
-        let order_ptr = self
-            .dynamic
-            .as_ptr()
-            .wrapping_add(offset + RBTREE_OVERHEAD_BYTES);
-        Some(unsafe { &*(order_ptr as *const RestingOrder) })
+    pub fn get_order(&self, index: DataIndex) -> Option<RestingOrder> {
+        self.read_payload(index, RESTING_ORDER_SIZE)
     }
 
     /// Get a claimed seat at the given index.
-    pub fn get_seat(&self, index: DataIndex) -> Option<&ClaimedSeat> {
-        if index == NIL {
-            return None;
-        }
-        let offset = index as usize;
-        if offset + RBTREE_OVERHEAD_BYTES + CLAIMED_SEAT_SIZE > self.dynamic.len() {
-            return None;
-        }
-        // Skip the RBNode header
-        let seat_ptr = self
-            .dynamic
-            .as_ptr()
-            .wrapping_add(offset + RBTREE_OVERHEAD_BYTES);
-        Some(unsafe { &*(seat_ptr as *const ClaimedSeat) })
+    pub fn get_seat(&self, index: DataIndex) -> Option<ClaimedSeat> {
+        self.read_payload(index, CLAIMED_SEAT_SIZE)
     }
 
     /// Get the best bid price as a float (or None if no bids).
@@ -274,41 +258,83 @@ impl<'a> Market<'a> {
     }
 
     /// Find a trader's seat by their pubkey.
-    pub fn find_trader_seat(&self, trader: &Pubkey) -> Option<(DataIndex, &ClaimedSeat)> {
+    pub fn find_trader_seat(&self, trader: &Pubkey) -> Option<(DataIndex, ClaimedSeat)> {
         // Walk the claimed seats tree to find the trader
         self.walk_tree_for_trader(self.fixed.claimed_seats_root_index, trader)
     }
 
     fn walk_tree_for_trader(
         &self,
-        index: DataIndex,
+        mut index: DataIndex,
         trader: &Pubkey,
-    ) -> Option<(DataIndex, &ClaimedSeat)> {
+    ) -> Option<(DataIndex, ClaimedSeat)> {
+        while index != NIL {
+            let seat = self.get_seat(index)?;
+            let seat_trader = seat.get_trader();
+            if &seat_trader == trader {
+                return Some((index, seat));
+            }
+            let header = self.get_header(index)?;
+            index = if trader.to_bytes() < seat_trader.to_bytes() {
+                header.left
+            } else {
+                header.right
+            };
+        }
+        None
+    }
+
+    fn get_header(&self, index: DataIndex) -> Option<RBNodeHeader> {
+        self.read_payload_at(index as usize, RBTREE_OVERHEAD_BYTES)
+    }
+
+    fn read_payload<T: Copy>(&self, index: DataIndex, size: usize) -> Option<T> {
         if index == NIL {
             return None;
         }
+        self.read_payload_at((index as usize).checked_add(RBTREE_OVERHEAD_BYTES)?, size)
+    }
 
-        let seat = self.get_seat(index)?;
-        let seat_trader = seat.get_trader();
-
-        if &seat_trader == trader {
-            return Some((index, seat));
-        }
-
-        // Get the node header to traverse the tree
-        let offset = index as usize;
-        if offset + RBTREE_OVERHEAD_BYTES > self.dynamic.len() {
+    fn read_payload_at<T: Copy>(&self, offset: usize, size: usize) -> Option<T> {
+        if size != std::mem::size_of::<T>() || offset.checked_add(size)? > self.dynamic.len() {
             return None;
         }
-        let header_ptr = self.dynamic.as_ptr().wrapping_add(offset);
-        let header = unsafe { &*(header_ptr as *const RBNodeHeader) };
+        Some(unsafe {
+            self.dynamic
+                .as_ptr()
+                .add(offset)
+                .cast::<T>()
+                .read_unaligned()
+        })
+    }
 
-        // Binary search based on trader pubkey comparison
-        if trader.to_bytes() < seat_trader.to_bytes() {
-            self.walk_tree_for_trader(header.left, trader)
-        } else {
-            self.walk_tree_for_trader(header.right, trader)
+    fn validate_tree(&self, root: DataIndex, payload_size: usize) -> Option<()> {
+        if root == NIL {
+            return Some(());
         }
+        let mut stack = vec![(root, NIL)];
+        let mut seen = HashSet::new();
+        while let Some((index, expected_parent)) = stack.pop() {
+            if index == NIL {
+                continue;
+            }
+            if index as usize % 8 != 0 || !seen.insert(index) {
+                return None;
+            }
+            let end = (index as usize)
+                .checked_add(RBTREE_OVERHEAD_BYTES)?
+                .checked_add(payload_size)?;
+            if end > self.dynamic.len() {
+                return None;
+            }
+            let header = self.get_header(index)?;
+            if header.color > 1 || header.parent != expected_parent {
+                return None;
+            }
+            stack.push((header.left, index));
+            stack.push((header.right, index));
+        }
+        Some(())
     }
 }
 
@@ -338,6 +364,53 @@ impl<'a> OrderIterator<'a> {
     }
 }
 
+#[cfg(test)]
+mod parsing_tests {
+    use super::*;
+
+    fn market_bytes(root: DataIndex) -> Vec<u8> {
+        let mut data = vec![0_u8; MARKET_FIXED_SIZE + RBTREE_OVERHEAD_BYTES + RESTING_ORDER_SIZE];
+        data[..8].copy_from_slice(&MARKET_FIXED_DISCRIMINANT.to_le_bytes());
+        let root_offset = std::mem::offset_of!(MarketFixed, bids_root_index);
+        data[root_offset..root_offset + 4].copy_from_slice(&root.to_le_bytes());
+        for field in [
+            std::mem::offset_of!(MarketFixed, bids_best_index),
+            std::mem::offset_of!(MarketFixed, asks_root_index),
+            std::mem::offset_of!(MarketFixed, asks_best_index),
+            std::mem::offset_of!(MarketFixed, claimed_seats_root_index),
+            std::mem::offset_of!(MarketFixed, free_list_head_index),
+        ] {
+            data[field..field + 4].copy_from_slice(&NIL.to_le_bytes());
+        }
+        data
+    }
+
+    #[test]
+    fn rejects_truncated_and_out_of_bounds_market_data() {
+        assert!(Market::try_from_bytes(&[]).is_none());
+        assert!(Market::try_from_bytes(&market_bytes(8)).is_none());
+    }
+
+    #[test]
+    fn rejects_cyclic_tree() {
+        let mut data = market_bytes(0);
+        let dynamic = &mut data[MARKET_FIXED_SIZE..];
+        dynamic[0..4].copy_from_slice(&0_u32.to_le_bytes());
+        dynamic[4..8].copy_from_slice(&NIL.to_le_bytes());
+        dynamic[8..12].copy_from_slice(&NIL.to_le_bytes());
+        assert!(Market::try_from_bytes(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_invalid_node_color() {
+        let mut data = market_bytes(0);
+        let dynamic = &mut data[MARKET_FIXED_SIZE..];
+        dynamic[0..12].copy_from_slice(&[0xff; 12]);
+        dynamic[12] = 2;
+        assert!(Market::try_from_bytes(&data).is_none());
+    }
+}
+
 impl<'a> Iterator for OrderIterator<'a> {
     type Item = (DataIndex, RestingOrder);
 
@@ -347,7 +420,7 @@ impl<'a> Iterator for OrderIterator<'a> {
         }
 
         let index = self.current_index;
-        let order = *self.market.get_order(index)?;
+        let order = self.market.get_order(index)?;
 
         // Get the next index by traversing the tree
         let offset = index as usize;
@@ -356,11 +429,10 @@ impl<'a> Iterator for OrderIterator<'a> {
             return Some((index, order));
         }
 
-        let header_ptr = self.market.dynamic.as_ptr().wrapping_add(offset);
-        let header = unsafe { &*(header_ptr as *const RBNodeHeader) };
+        let header = self.market.get_header(index)?;
 
         // Get next lower index in the tree
-        self.current_index = self.get_next_lower_index(index, header);
+        self.current_index = self.get_next_lower_index(index, &header);
 
         Some((index, order))
     }
@@ -376,8 +448,8 @@ impl<'a> OrderIterator<'a> {
                 if offset + RBTREE_OVERHEAD_BYTES > self.market.dynamic.len() {
                     break;
                 }
-                let h = unsafe {
-                    &*(self.market.dynamic.as_ptr().wrapping_add(offset) as *const RBNodeHeader)
+                let Some(h) = self.market.get_header(index) else {
+                    return NIL;
                 };
                 if h.right == NIL {
                     return index;
@@ -396,8 +468,8 @@ impl<'a> OrderIterator<'a> {
             if offset + RBTREE_OVERHEAD_BYTES > self.market.dynamic.len() {
                 return NIL;
             }
-            let parent_header = unsafe {
-                &*(self.market.dynamic.as_ptr().wrapping_add(offset) as *const RBNodeHeader)
+            let Some(parent_header) = self.market.get_header(parent_idx) else {
+                return NIL;
             };
 
             if parent_header.right == child {

--- a/client/ts/src/fillFeed.ts
+++ b/client/ts/src/fillFeed.ts
@@ -16,6 +16,7 @@ import {
 } from './utils/inferFills';
 import * as promClient from 'prom-client';
 import { FillLogResult } from './types';
+import { extractProgramDataLogs } from './utils/programLogs';
 import {
   detectAggregatorFromKeys,
   detectOriginatingProtocolFromKeys,
@@ -265,9 +266,12 @@ export class FillFeed {
       this.onTruncatedLogs?.(signature.signature, signature.slot);
     }
 
-    const programDatas: string[] = messages.filter((message) => {
-      return message.includes('Program data:');
-    });
+    // Attribute logs to the active invocation stack; any program can emit the
+    // same "Program data" bytes, so transaction account presence is not proof.
+    const programDatas = extractProgramDataLogs(
+      messages,
+      PROGRAM_ID.toBase58(),
+    );
 
     if (programDatas.length == 0 && !truncated) {
       console.log('No program datas');
@@ -276,17 +280,21 @@ export class FillFeed {
 
     const parsedFills: FillLogResult[] = [];
     for (const programDataEntry of programDatas) {
-      const programData = programDataEntry.split(' ')[2];
-      const byteArray: Uint8Array = Uint8Array.from(atob(programData), (c) =>
-        c.charCodeAt(0),
-      );
-      const buffer = Buffer.from(byteArray);
-      if (!buffer.subarray(0, 8).equals(fillDiscriminant)) {
+      let buffer: Buffer;
+      let deserializedFillLog: FillLog;
+      try {
+        buffer = Buffer.from(programDataEntry.data, 'base64');
+        if (
+          buffer.length < 8 ||
+          !buffer.subarray(0, 8).equals(fillDiscriminant)
+        ) {
+          continue;
+        }
+        deserializedFillLog = FillLog.deserialize(buffer.subarray(8))[0];
+      } catch (error) {
+        console.warn('Skipping malformed Manifest program data:', error);
         continue;
       }
-      const deserializedFillLog: FillLog = FillLog.deserialize(
-        buffer.subarray(8),
-      )[0];
       const fillResult = toFillLogResult(
         deserializedFillLog,
         signature.slot,
@@ -298,6 +306,7 @@ export class FillFeed {
         // ?? undefined because can be null or undefined
         signature.blockTime ?? undefined,
       );
+      fillResult.invocationIndex = programDataEntry.invocationIndex;
       const resultString: string = JSON.stringify(fillResult);
       console.log('Got a fill', resultString);
       parsedFills.push(fillResult);

--- a/client/ts/src/fillFeedBlockSub.ts
+++ b/client/ts/src/fillFeedBlockSub.ts
@@ -15,6 +15,7 @@ import {
   computeInferredRemainders,
 } from './utils/inferFills';
 import { FillLogResult } from './types';
+import { extractProgramDataLogs } from './utils/programLogs';
 
 // For live monitoring of the fill feed. For a more complete look at fill
 // history stats, need to index all trades.
@@ -32,6 +33,8 @@ const inferredFills = new promClient.Counter({
   help: 'Number of fills inferred from token transfers due to truncated logs',
   labelNames: ['market'] as const,
 });
+const SLOT_PAGE_SIZE = 32;
+const MAX_SLOT_LAG = 10_000;
 
 /**
  * FillFeedBlockSub - Processes blocks sequentially using getBlock to find Manifest program transactions
@@ -93,9 +96,22 @@ export class FillFeedBlockSub {
           // Get the latest finalized slot
           const latestSlot = await this.connection.getSlot('finalized');
 
-          // Determine which slots need to be processed
+          if (latestSlot - this.currentSlot > MAX_SLOT_LAG) {
+            const clampedSlot = latestSlot - MAX_SLOT_LAG;
+            console.warn(
+              `Clamping block-feed lag from ${this.currentSlot} to ${clampedSlot}`,
+            );
+            this.currentSlot = clampedSlot;
+          }
+
+          // Process a bounded page so an RPC-reported jump cannot allocate or
+          // fetch an unbounded slot range in one Promise.all.
+          const pageEnd = Math.min(
+            latestSlot,
+            this.currentSlot + SLOT_PAGE_SIZE - 1,
+          );
           const slotsToProcess: number[] = [];
-          for (let slot = this.currentSlot; slot <= latestSlot; slot++) {
+          for (let slot = this.currentSlot; slot <= pageEnd; slot++) {
             slotsToProcess.push(slot);
           }
 
@@ -105,7 +121,7 @@ export class FillFeedBlockSub {
           }
 
           console.log(
-            `Fetching ${slotsToProcess.length} blocks in parallel (${this.currentSlot} to ${latestSlot})`,
+            `Fetching ${slotsToProcess.length} blocks in parallel (${this.currentSlot} to ${pageEnd})`,
           );
 
           // Fetch all blocks in parallel
@@ -153,7 +169,7 @@ export class FillFeedBlockSub {
           }
 
           // Update current slot to continue from the next unprocessed slot
-          this.currentSlot = latestSlot + 1;
+          this.currentSlot = pageEnd + 1;
         } catch (error) {
           console.error(
             `Error processing blocks from ${this.currentSlot}:`,
@@ -302,9 +318,11 @@ export class FillFeedBlockSub {
       this.onTruncatedLogs?.(signature, slot);
     }
 
-    const programDatas: string[] = messages.filter((message) => {
-      return message.includes('Program data:');
-    });
+    // Do not deserialize spoofable data emitted by unrelated CPI programs.
+    const programDatas = extractProgramDataLogs(
+      messages,
+      PROGRAM_ID.toBase58(),
+    );
 
     if (programDatas.length === 0 && !truncated) {
       console.log('No program datas');
@@ -313,17 +331,21 @@ export class FillFeedBlockSub {
 
     const parsedFills: FillLogResult[] = [];
     for (const programDataEntry of programDatas) {
-      const programData = programDataEntry.split(' ')[2];
-      const byteArray: Uint8Array = Uint8Array.from(atob(programData), (c) =>
-        c.charCodeAt(0),
-      );
-      const buffer = Buffer.from(byteArray);
-      if (!buffer.subarray(0, 8).equals(fillDiscriminant)) {
+      let buffer: Buffer;
+      let deserializedFillLog: FillLog;
+      try {
+        buffer = Buffer.from(programDataEntry.data, 'base64');
+        if (
+          buffer.length < 8 ||
+          !buffer.subarray(0, 8).equals(fillDiscriminant)
+        ) {
+          continue;
+        }
+        deserializedFillLog = FillLog.deserialize(buffer.subarray(8))[0];
+      } catch (error) {
+        console.warn('Skipping malformed Manifest program data:', error);
         continue;
       }
-      const deserializedFillLog: FillLog = FillLog.deserialize(
-        buffer.subarray(8),
-      )[0];
       const fillResult = toFillLogResult(
         deserializedFillLog,
         slot,
@@ -334,6 +356,7 @@ export class FillFeedBlockSub {
         signers,
         blockTime ?? undefined,
       );
+      fillResult.invocationIndex = programDataEntry.invocationIndex;
       const resultString: string = JSON.stringify(fillResult);
       console.log('Got a fill', resultString);
       parsedFills.push(fillResult);

--- a/client/ts/src/market.ts
+++ b/client/ts/src/market.ts
@@ -902,15 +902,19 @@ export class Market {
       filters,
     });
 
-    return accounts
-      .map(({ account, pubkey }) =>
-        Market.loadFromBuffer({ address: pubkey, buffer: account.data }),
-      )
-      .sort((a, b) =>
-        new BN(b.quoteVolume().toString())
-          .sub(new BN(a.quoteVolume().toString()))
-          .toNumber(),
-      );
+    return (
+      accounts
+        .map(({ account, pubkey }) =>
+          Market.loadFromBuffer({ address: pubkey, buffer: account.data }),
+        )
+        // BN subtraction converted to Number can lose precision and misorder
+        // attacker-controlled on-chain volumes; cmp stays in arbitrary precision.
+        .sort((a, b) =>
+          new BN(b.quoteVolume().toString()).cmp(
+            new BN(a.quoteVolume().toString()),
+          ),
+        )
+    );
   }
 
   static async setupIxs(

--- a/client/ts/src/types.ts
+++ b/client/ts/src/types.ts
@@ -26,6 +26,8 @@ export type FillLogResult = {
   slot: number;
   /** Signature of the tx where the fill happened. */
   signature: string;
+  /** Zero-based Manifest invocation index within the transaction. */
+  invocationIndex?: number;
   /**
    * Public key of the original transaction signer as base58.
    * This represents the actual user when trades go through aggregators.

--- a/client/ts/src/utils/WebSocketManager.ts
+++ b/client/ts/src/utils/WebSocketManager.ts
@@ -4,22 +4,47 @@ import WebSocket from 'ws';
  * Manages WebSocket server with client heartbeat functionality
  */
 export class WebSocketManager {
+  private static readonly MAX_CLIENTS = 100;
+  private static readonly MAX_CLIENTS_PER_IP = 10;
+  private static readonly MAX_PAYLOAD_BYTES = 64 * 1024;
+  private static readonly MAX_BUFFERED_BYTES = 1024 * 1024;
   private wss: WebSocket.Server;
   private clientHeartbeats: Map<WebSocket, NodeJS.Timeout> = new Map();
+  private clientsByIp: Map<string, number> = new Map();
   private heartbeatInterval: number;
 
-  constructor(port: number, heartbeatInterval: number = 30000) {
+  constructor(
+    port: number,
+    heartbeatInterval: number = 30000,
+    host: string = process.env.FILL_FEED_WS_HOST ?? '127.0.0.1',
+  ) {
     this.heartbeatInterval = heartbeatInterval;
-    this.wss = new WebSocket.Server({ port });
+    this.wss = new WebSocket.Server({
+      // Bind locally by default and cap frames to keep this unauthenticated
+      // broadcast endpoint from becoming a public memory/connection sink.
+      port,
+      host,
+      maxPayload: WebSocketManager.MAX_PAYLOAD_BYTES,
+    });
 
-    this.wss.on('connection', (ws: WebSocket) => {
+    this.wss.on('connection', (ws: WebSocket, request) => {
+      const ip = request.socket.remoteAddress ?? 'unknown';
+      const ipClients = this.clientsByIp.get(ip) ?? 0;
+      if (
+        this.wss.clients.size > WebSocketManager.MAX_CLIENTS ||
+        ipClients >= WebSocketManager.MAX_CLIENTS_PER_IP
+      ) {
+        ws.close(1013, 'Server capacity reached');
+        return;
+      }
+      this.clientsByIp.set(ip, ipClients + 1);
       console.log('New client connected');
 
       // Start heartbeat for this client
       this.startClientHeartbeat(ws);
 
-      ws.on('message', (message: string) => {
-        console.log(`Received message: ${message}`);
+      ws.on('message', () => {
+        ws.close(1008, 'Inbound messages are not supported');
       });
 
       ws.on('pong', () => {
@@ -30,6 +55,12 @@ export class WebSocketManager {
       ws.on('close', () => {
         console.log('Client disconnected');
         this.stopClientHeartbeat(ws);
+        const remaining = (this.clientsByIp.get(ip) ?? 1) - 1;
+        if (remaining > 0) {
+          this.clientsByIp.set(ip, remaining);
+        } else {
+          this.clientsByIp.delete(ip);
+        }
       });
 
       ws.on('error', (error) => {
@@ -45,6 +76,12 @@ export class WebSocketManager {
   public broadcast(message: string): void {
     this.wss.clients.forEach((client) => {
       if (client.readyState === WebSocket.OPEN) {
+        // Disconnect slow consumers before queued broadcasts grow without bound.
+        if (client.bufferedAmount > WebSocketManager.MAX_BUFFERED_BYTES) {
+          client.terminate();
+          this.stopClientHeartbeat(client);
+          return;
+        }
         client.send(message);
       }
     });

--- a/client/ts/src/utils/beet.ts
+++ b/client/ts/src/utils/beet.ts
@@ -1,4 +1,4 @@
-import { BeetArgsStruct, u32 } from '@metaplex-foundation/beet';
+import { BeetArgsStruct, u8, u16, u32 } from '@metaplex-foundation/beet';
 import { publicKey as beetPublicKey } from '@metaplex-foundation/beet-solana';
 import { RedBlackTreeNodeHeader } from './redBlackTree';
 import { PublicKey } from '@solana/web3.js';
@@ -26,7 +26,9 @@ export const redBlackTreeHeaderBeet =
       ['left', u32],
       ['right', u32],
       ['parent', u32],
-      ['color', u32],
+      ['color', u8],
+      ['payloadType', u8],
+      ['padding', u16],
     ],
     'redBlackTreeNodeHeader',
   );

--- a/client/ts/src/utils/inferFills.ts
+++ b/client/ts/src/utils/inferFills.ts
@@ -176,6 +176,7 @@ interface SwapSite {
   instruction: NormalizedInstruction;
   layout: SwapAccountLayout;
   cpiInstructions: NormalizedInstruction[];
+  invocationIndex: number;
 }
 
 function swapAccountLayout(
@@ -201,6 +202,7 @@ function swapAccountLayout(
  */
 function findSwapSites(tx: any, accountKeys: string[]): SwapSite[] {
   const sites: SwapSite[] = [];
+  const manifestProgramId = PROGRAM_ID.toBase58();
   const innerGroups: any[] = tx.meta?.innerInstructions ?? [];
   const innerByTopIndex: Map<number, NormalizedInstruction[]> = new Map();
   for (const group of innerGroups) {
@@ -210,24 +212,31 @@ function findSwapSites(tx: any, accountKeys: string[]): SwapSite[] {
     );
   }
 
-  topLevelInstructions(tx, accountKeys).forEach(
-    (ix: NormalizedInstruction, topIndex: number) => {
-      const layout: SwapAccountLayout | undefined = swapAccountLayout(ix);
-      if (layout) {
-        sites.push({
-          instruction: ix,
-          layout,
-          cpiInstructions: innerByTopIndex.get(topIndex) ?? [],
-        });
-      }
-    },
-  );
+  let manifestInvocationIndex = 0;
+  topLevelInstructions(tx, accountKeys).forEach((topIx, topIndex) => {
+    const topInvocationIndex =
+      topIx.programId === manifestProgramId
+        ? manifestInvocationIndex++
+        : undefined;
+    const topLayout = swapAccountLayout(topIx);
+    const group = innerByTopIndex.get(topIndex) ?? [];
+    if (topLayout && topInvocationIndex !== undefined) {
+      sites.push({
+        instruction: topIx,
+        layout: topLayout,
+        cpiInstructions: group,
+        invocationIndex: topInvocationIndex,
+      });
+    }
 
-  for (const group of innerByTopIndex.values()) {
     for (let i = 0; i < group.length; i++) {
       const ix: NormalizedInstruction = group[i];
+      const invocationIndex =
+        ix.programId === manifestProgramId
+          ? manifestInvocationIndex++
+          : undefined;
       const layout: SwapAccountLayout | undefined = swapAccountLayout(ix);
-      if (!layout) {
+      if (!layout || invocationIndex === undefined) {
         continue;
       }
       const cpiInstructions: NormalizedInstruction[] = [];
@@ -237,9 +246,9 @@ function findSwapSites(tx: any, accountKeys: string[]): SwapSite[] {
         }
         cpiInstructions.push(group[j]);
       }
-      sites.push({ instruction: ix, layout, cpiInstructions });
+      sites.push({ instruction: ix, layout, cpiInstructions, invocationIndex });
     }
-  }
+  });
   return sites;
 }
 
@@ -328,6 +337,7 @@ export function inferFillsFromTransaction(
       takerSequenceNumber: '0',
       signature,
       slot,
+      invocationIndex: site.invocationIndex,
     };
     if (extras.originalSigner) {
       result.originalSigner = extras.originalSigner;
@@ -361,17 +371,27 @@ export function computeInferredRemainders(
   parsed: FillLogResult[],
 ): FillLogResult[] {
   const remainders: FillLogResult[] = [];
+  // Reconcile within the same Manifest invocation. Matching only market/taker
+  // lets one parsed fill erase a distinct inferred swap in the transaction.
+  const consumedParsed = new Set<number>();
   for (const fill of inferred) {
     let baseAtoms: bigint = BigInt(fill.baseAtoms);
     let quoteAtoms: bigint = BigInt(fill.quoteAtoms);
-    for (const parsedFill of parsed) {
+    for (let index = 0; index < parsed.length; index++) {
+      if (consumedParsed.has(index)) {
+        continue;
+      }
+      const parsedFill = parsed[index];
       if (
+        fill.invocationIndex !== undefined &&
+        parsedFill.invocationIndex === fill.invocationIndex &&
         parsedFill.market === fill.market &&
         parsedFill.taker === fill.taker &&
         parsedFill.takerIsBuy === fill.takerIsBuy
       ) {
         baseAtoms -= BigInt(parsedFill.baseAtoms);
         quoteAtoms -= BigInt(parsedFill.quoteAtoms);
+        consumedParsed.add(index);
       }
     }
     if (baseAtoms > 0n && quoteAtoms > 0n) {

--- a/client/ts/src/utils/programLogs.ts
+++ b/client/ts/src/utils/programLogs.ts
@@ -1,0 +1,65 @@
+export interface ProgramDataLog {
+  data: string;
+  invocationIndex: number;
+}
+
+interface InvocationFrame {
+  programId: string;
+  targetInvocationIndex?: number;
+}
+
+const INVOKE_PATTERN = /^Program ([1-9A-HJ-NP-Za-km-z]+) invoke \[\d+\]$/;
+const EXIT_PATTERN =
+  /^Program ([1-9A-HJ-NP-Za-km-z]+) (?:success|failed(?::.*)?)$/;
+const DATA_PREFIX = 'Program data: ';
+
+/**
+ * Return only data emitted while the requested program is the active Solana
+ * invocation frame. The invocation index is stable across top-level and CPI
+ * calls and can be used to associate decoded events with inferred effects.
+ */
+export function extractProgramDataLogs(
+  messages: string[],
+  targetProgramId: string,
+): ProgramDataLog[] {
+  const frames: InvocationFrame[] = [];
+  const results: ProgramDataLog[] = [];
+  let targetInvocationIndex = 0;
+
+  for (const message of messages) {
+    const invoke = message.match(INVOKE_PATTERN);
+    if (invoke) {
+      const frame: InvocationFrame = { programId: invoke[1] };
+      if (frame.programId === targetProgramId) {
+        frame.targetInvocationIndex = targetInvocationIndex++;
+      }
+      frames.push(frame);
+      continue;
+    }
+
+    const exit = message.match(EXIT_PATTERN);
+    if (exit) {
+      const frame = frames.at(-1);
+      if (frame?.programId === exit[1]) {
+        frames.pop();
+      } else {
+        frames.length = 0;
+      }
+      continue;
+    }
+
+    const active = frames.at(-1);
+    if (
+      active?.programId === targetProgramId &&
+      active.targetInvocationIndex !== undefined &&
+      message.startsWith(DATA_PREFIX)
+    ) {
+      results.push({
+        data: message.slice(DATA_PREFIX.length),
+        invocationIndex: active.targetInvocationIndex,
+      });
+    }
+  }
+
+  return results;
+}

--- a/client/ts/src/utils/redBlackTree.ts
+++ b/client/ts/src/utils/redBlackTree.ts
@@ -8,121 +8,90 @@ export type RedBlackTreeNodeHeader = {
   right: bignum;
   parent: bignum;
   color: bignum;
+  payloadType: bignum;
+  padding: bignum;
 };
+
 const NUM_TREE_HEADER_BYTES = 16;
+const TREE_NODE_ALIGNMENT = 8;
 
 /**
- * Deserializes a RedBlackTree from a given buffer into a list
- * @description This deserializes the RedBlackTree defined in https://github.com/Bonasa-Tech/manifest/blob/main/src/state/red_black_tree.rs
- *
- * @param data The data buffer to deserialize
- * @param rootIndex Index in the buffer for the root
- * @param valueDeserializer The deserializer for the tree value
+ * Deserializes an account-backed red-black tree after validating every
+ * reachable node. RPC account bytes are untrusted, so malformed offsets and
+ * cycles must fail closed instead of reading truncated buffers or looping.
  */
 export function deserializeRedBlackTree<Value>(
   data: Buffer,
   rootIndex: number,
   valueDeserializer: BeetArgsStruct<Value>,
 ): Value[] {
+  if (rootIndex === NIL) {
+    return [];
+  }
+
+  const nodeSize = NUM_TREE_HEADER_BYTES + valueDeserializer.byteSize;
+  const headers = new Map<number, RedBlackTreeNodeHeader>();
+  const visiting = new Set<number>();
+  const visited = new Set<number>();
+
+  const readHeader = (index: number): RedBlackTreeNodeHeader => {
+    if (
+      !Number.isSafeInteger(index) ||
+      index < 0 ||
+      index % TREE_NODE_ALIGNMENT !== 0 ||
+      index + nodeSize > data.length
+    ) {
+      throw new Error(`Invalid red-black tree node offset: ${index}`);
+    }
+    const cached = headers.get(index);
+    if (cached) return cached;
+    const [header] = redBlackTreeHeaderBeet.deserialize(
+      data.subarray(index, index + NUM_TREE_HEADER_BYTES),
+    );
+    const color = toNum(header.color);
+    if (color !== 0 && color !== 1) {
+      throw new Error(`Invalid red-black tree color at offset ${index}`);
+    }
+    headers.set(index, header);
+    return header;
+  };
+
+  const validate = (index: number, expectedParent: number): void => {
+    if (index === NIL) return;
+    if (visiting.has(index) || visited.has(index)) {
+      throw new Error(
+        `Cycle or duplicate red-black tree node at offset ${index}`,
+      );
+    }
+    visiting.add(index);
+    const header = readHeader(index);
+    if (toNum(header.parent) !== expectedParent) {
+      throw new Error(`Invalid red-black tree parent at offset ${index}`);
+    }
+    validate(toNum(header.left), index);
+    validate(toNum(header.right), index);
+    visiting.delete(index);
+    visited.add(index);
+  };
+  validate(rootIndex, NIL);
+
   const result: Value[] = [];
-  const [rootHeaderValue] = redBlackTreeHeaderBeet.deserialize(
-    data.subarray(rootIndex, rootIndex + NUM_TREE_HEADER_BYTES),
-  );
-
-  // Find the min
-  let currentHeader = rootHeaderValue;
-  let currentIndex = rootIndex;
-  while (toNum(currentHeader.left) != NIL) {
-    currentIndex = toNum(currentHeader.left);
-
-    const [currentHeaderTemp] = redBlackTreeHeaderBeet.deserialize(
-      data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),
-    );
-    currentHeader = currentHeaderTemp;
-  }
-
-  // Keep going while there is a successor.
-  const [currentValue] = valueDeserializer.deserialize(
-    data.subarray(
-      currentIndex + NUM_TREE_HEADER_BYTES,
-      currentIndex + NUM_TREE_HEADER_BYTES + valueDeserializer.byteSize,
-    ),
-  );
-
-  result.push(currentValue);
-  while (getSuccessorIndex(data, currentIndex) != NIL) {
-    currentIndex = getSuccessorIndex(data, currentIndex);
-    const [currentValue] = valueDeserializer.deserialize(
+  const stack: number[] = [];
+  let current = rootIndex;
+  while (current !== NIL || stack.length > 0) {
+    while (current !== NIL) {
+      stack.push(current);
+      current = toNum(readHeader(current).left);
+    }
+    const index = stack.pop()!;
+    const [value] = valueDeserializer.deserialize(
       data.subarray(
-        currentIndex + NUM_TREE_HEADER_BYTES,
-        currentIndex + NUM_TREE_HEADER_BYTES + valueDeserializer.byteSize,
+        index + NUM_TREE_HEADER_BYTES,
+        index + NUM_TREE_HEADER_BYTES + valueDeserializer.byteSize,
       ),
     );
-    result.push(currentValue);
+    result.push(value);
+    current = toNum(readHeader(index).right);
   }
-
   return result;
-}
-
-function getSuccessorIndex(data: Buffer, index: number) {
-  if (index == NIL) {
-    return NIL;
-  }
-  let [currentHeader] = redBlackTreeHeaderBeet.deserialize(
-    data.subarray(index, index + NUM_TREE_HEADER_BYTES),
-  );
-  let currentIndex = index;
-
-  // Successor is below, go right then all the way to the left.
-  if (toNum(currentHeader.right) != NIL) {
-    currentIndex = toNum(currentHeader.right);
-    currentHeader = redBlackTreeHeaderBeet.deserialize(
-      data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),
-    )[0];
-    while (toNum(currentHeader.left) != NIL) {
-      currentIndex = toNum(currentHeader.left);
-      currentHeader = redBlackTreeHeaderBeet.deserialize(
-        data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),
-      )[0];
-    }
-    return currentIndex;
-  }
-
-  if (currentHeader.parent == NIL) {
-    return NIL;
-  }
-  let [parentHeader] = redBlackTreeHeaderBeet.deserialize(
-    data.subarray(
-      toNum(currentHeader.parent),
-      toNum(currentHeader.parent) + NUM_TREE_HEADER_BYTES,
-    ),
-  );
-  // Successor is above, keep going up while we are the right child
-  while (toNum(parentHeader.right) == currentIndex) {
-    currentIndex = toNum(currentHeader.parent);
-    if (currentIndex == NIL) {
-      return NIL;
-    }
-    currentHeader = redBlackTreeHeaderBeet.deserialize(
-      data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),
-    )[0];
-    if (currentHeader.parent == NIL) {
-      return NIL;
-    }
-    parentHeader = redBlackTreeHeaderBeet.deserialize(
-      data.subarray(
-        toNum(currentHeader.parent),
-        toNum(currentHeader.parent) + NUM_TREE_HEADER_BYTES,
-      ),
-    )[0];
-  }
-
-  // Go up once more.
-  currentHeader = redBlackTreeHeaderBeet.deserialize(
-    data.subarray(currentIndex, currentIndex + NUM_TREE_HEADER_BYTES),
-  )[0];
-  if (currentHeader.parent == NIL) {
-    return NIL;
-  }
-  return toNum(currentHeader.parent);
 }

--- a/client/ts/tests/httpValidation.ts
+++ b/client/ts/tests/httpValidation.ts
@@ -1,0 +1,38 @@
+import { assert } from 'chai';
+import {
+  isAuthorizedBearer,
+  isValidSolanaSignature,
+  parseBoundedQueryInteger,
+} from '../../../scripts/stats_utils/httpValidation';
+
+describe('stats HTTP validation', () => {
+  it('accepts bounded integer query values', () => {
+    assert.equal(
+      parseBoundedQueryInteger(undefined, 100, 1, 500, 'limit'),
+      100,
+    );
+    assert.equal(parseBoundedQueryInteger('500', 100, 1, 500, 'limit'), 500);
+  });
+
+  it('rejects malformed or excessive query values', () => {
+    for (const value of ['-1', '1.5', '501', 'not-a-number']) {
+      assert.throws(() =>
+        parseBoundedQueryInteger(value, 100, 1, 500, 'limit'),
+      );
+    }
+  });
+
+  it('compares bearer credentials without accepting partial tokens', () => {
+    assert.isTrue(
+      isAuthorizedBearer('Bearer operator-secret', 'operator-secret'),
+    );
+    assert.isFalse(isAuthorizedBearer('Bearer operator', 'operator-secret'));
+    assert.isFalse(isAuthorizedBearer(undefined, 'operator-secret'));
+  });
+
+  it('validates base58 transaction signatures', () => {
+    assert.isTrue(isValidSolanaSignature('1'.repeat(64)));
+    assert.isFalse(isValidSolanaSignature('0'.repeat(64)));
+    assert.isFalse(isValidSolanaSignature('1'.repeat(63)));
+  });
+});

--- a/client/ts/tests/inferFillsReconciliation.ts
+++ b/client/ts/tests/inferFillsReconciliation.ts
@@ -1,0 +1,46 @@
+import { assert } from 'chai';
+import { FillLogResult } from '../src/types';
+import { computeInferredRemainders } from '../src/utils/inferFills';
+
+function fill(
+  invocationIndex: number,
+  baseAtoms: string,
+  quoteAtoms: string,
+): FillLogResult {
+  return {
+    market: 'market',
+    maker: '',
+    taker: 'taker',
+    baseAtoms,
+    quoteAtoms,
+    priceAtoms: Number(quoteAtoms) / Number(baseAtoms),
+    takerIsBuy: true,
+    isMakerGlobal: false,
+    makerSequenceNumber: '0',
+    takerSequenceNumber: '0',
+    signature: 'signature',
+    slot: 1,
+    invocationIndex,
+  };
+}
+
+describe('inferred fill reconciliation', () => {
+  it('subtracts a parsed fill only from its own invocation', () => {
+    const remainders = computeInferredRemainders(
+      [fill(0, '10', '20'), fill(1, '30', '60')],
+      [fill(0, '4', '8')],
+    );
+
+    assert.deepEqual(
+      remainders.map(({ invocationIndex, baseAtoms, quoteAtoms }) => ({
+        invocationIndex,
+        baseAtoms,
+        quoteAtoms,
+      })),
+      [
+        { invocationIndex: 0, baseAtoms: '6', quoteAtoms: '12' },
+        { invocationIndex: 1, baseAtoms: '30', quoteAtoms: '60' },
+      ],
+    );
+  });
+});

--- a/client/ts/tests/programLogs.ts
+++ b/client/ts/tests/programLogs.ts
@@ -1,0 +1,39 @@
+import { assert } from 'chai';
+import { extractProgramDataLogs } from '../src/utils/programLogs';
+
+const MANIFEST = 'MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms';
+const OTHER = '11111111111111111111111111111111';
+
+describe('program log attribution', () => {
+  it('accepts data only from the active Manifest invocation frame', () => {
+    const logs = [
+      `Program ${OTHER} invoke [1]`,
+      'Program data: forged-top-level',
+      `Program ${MANIFEST} invoke [2]`,
+      'Program data: real-cpi',
+      `Program ${MANIFEST} success`,
+      'Program data: forged-after-cpi',
+      `Program ${OTHER} success`,
+    ];
+
+    assert.deepEqual(extractProgramDataLogs(logs, MANIFEST), [
+      { data: 'real-cpi', invocationIndex: 0 },
+    ]);
+  });
+
+  it('assigns stable indexes to separate Manifest invocations', () => {
+    const logs = [
+      `Program ${MANIFEST} invoke [1]`,
+      'Program data: first',
+      `Program ${MANIFEST} success`,
+      `Program ${MANIFEST} invoke [1]`,
+      'Program data: second',
+      `Program ${MANIFEST} success`,
+    ];
+
+    assert.deepEqual(extractProgramDataLogs(logs, MANIFEST), [
+      { data: 'first', invocationIndex: 0 },
+      { data: 'second', invocationIndex: 1 },
+    ]);
+  });
+});

--- a/client/ts/tests/redBlackTreeValidation.ts
+++ b/client/ts/tests/redBlackTreeValidation.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { BeetArgsStruct, u32 } from '@metaplex-foundation/beet';
+import { NIL } from '../src/constants';
+import { deserializeRedBlackTree } from '../src/utils/redBlackTree';
+
+type TestValue = { value: number };
+const valueBeet = new BeetArgsStruct<TestValue>([['value', u32]], 'TestValue');
+
+function writeNode(
+  data: Buffer,
+  offset: number,
+  left: number,
+  right: number,
+  parent: number,
+  value: number,
+): void {
+  data.writeUInt32LE(left, offset);
+  data.writeUInt32LE(right, offset + 4);
+  data.writeUInt32LE(parent, offset + 8);
+  data.writeUInt8(0, offset + 12);
+  data.writeUInt32LE(value, offset + 16);
+}
+
+describe('red-black tree validation', () => {
+  it('deserializes a validated tree in order', () => {
+    const data = Buffer.alloc(44);
+    writeNode(data, 0, NIL, 24, NIL, 1);
+    writeNode(data, 24, NIL, NIL, 0, 2);
+    expect(deserializeRedBlackTree(data, 0, valueBeet)).to.deep.equal([
+      { value: 1 },
+      { value: 2 },
+    ]);
+  });
+
+  it('rejects cycles and out-of-bounds offsets', () => {
+    const cyclic = Buffer.alloc(20);
+    writeNode(cyclic, 0, 0, NIL, NIL, 1);
+    expect(() => deserializeRedBlackTree(cyclic, 0, valueBeet)).to.throw(
+      /Cycle or duplicate/,
+    );
+
+    const outOfBounds = Buffer.alloc(20);
+    writeNode(outOfBounds, 0, NIL, 24, NIL, 1);
+    expect(() => deserializeRedBlackTree(outOfBounds, 0, valueBeet)).to.throw(
+      /offset/,
+    );
+  });
+});

--- a/lib/src/red_black_tree.rs
+++ b/lib/src/red_black_tree.rs
@@ -1,6 +1,5 @@
 use bytemuck::{Pod, Zeroable};
-use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::{cmp::Ordering, collections::HashSet};
 
 use crate::{
     get_helper, get_mut_helper, trace, DataIndex, Get, HyperTreeReadOperations,

--- a/lib/src/red_black_tree.rs
+++ b/lib/src/red_black_tree.rs
@@ -1,5 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 use crate::{
     get_helper, get_mut_helper, trace, DataIndex, Get, HyperTreeReadOperations,
@@ -131,6 +132,53 @@ impl<'a, V: Payload> RedBlackTreeReadOnly<'a, V> {
             phantom: std::marker::PhantomData,
         }
     }
+}
+
+/// Validates all offsets and links reachable from an account-backed tree before
+/// callers use the zero-copy traversal API on untrusted RPC bytes.
+pub fn validate_red_black_tree<V: Payload>(
+    data: &[u8],
+    root_index: DataIndex,
+    max_index: DataIndex,
+) -> Result<(), &'static str> {
+    if root_index == NIL {
+        return if max_index == NIL {
+            Ok(())
+        } else {
+            Err("empty tree has a max node")
+        };
+    }
+
+    let mut stack = vec![(root_index, NIL)];
+    let mut seen = HashSet::new();
+    while let Some((index, expected_parent)) = stack.pop() {
+        if index == NIL {
+            continue;
+        }
+        let offset = index as usize;
+        let end = offset
+            .checked_add(core::mem::size_of::<RBNode<V>>())
+            .ok_or("tree node offset overflow")?;
+        if offset % 8 != 0 || end > data.len() {
+            return Err("tree node offset is out of bounds or misaligned");
+        }
+        if !seen.insert(index) {
+            return Err("tree contains a cycle or duplicate child");
+        }
+        let node = bytemuck::pod_read_unaligned::<RBNode<V>>(&data[offset..end]);
+        if node.color != Color::Black && node.color != Color::Red {
+            return Err("tree node has invalid color");
+        }
+        if node.parent != expected_parent {
+            return Err("tree node has inconsistent parent");
+        }
+        stack.push((node.left, index));
+        stack.push((node.right, index));
+    }
+    if max_index != NIL && !seen.contains(&max_index) {
+        return Err("tree max node is not reachable");
+    }
+    Ok(())
 }
 
 // Specific to red black trees and not all data structures. Implementing this
@@ -917,26 +965,18 @@ impl<'a, T: HyperTreeReadOperations<'a> + GetRedBlackTreeReadOnlyData<'a>, V: Pa
     }
 }
 
-#[cfg(feature = "certora")]
-#[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
-pub enum Color {
-    #[default]
-    Black = 0,
-    Red = 1,
-}
-#[cfg(not(feature = "certora"))]
-#[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
-pub(crate) enum Color {
-    #[default]
-    Black = 0,
-    Red = 1,
-}
-unsafe impl Zeroable for Color {
-    fn zeroed() -> Self {
-        unsafe { core::mem::zeroed() }
-    }
+// Keep the on-chain byte representation while allowing every possible byte
+// pattern. A Rust enum is not Pod because discriminants other than 0 and 1 are
+// invalid and constructing one from untrusted account bytes is undefined
+// behavior.
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pod, Zeroable)]
+pub struct Color(u8);
+
+#[allow(non_upper_case_globals)]
+impl Color {
+    pub const Black: Self = Self(0);
+    pub const Red: Self = Self(1);
 }
 
 #[cfg(feature = "certora")]
@@ -1586,6 +1626,25 @@ pub(crate) mod test {
             tree.insert(TEST_BLOCK_WIDTH * i, TestOrderBid::new((i * 1_000).into()));
         }
         tree
+    }
+
+    #[test]
+    fn test_validate_rejects_cycles_and_invalid_colors() {
+        let mut data = [0_u8; 4096];
+        let (root, max) = {
+            let tree = init_simple_tree(&mut data);
+            (tree.get_root_index(), tree.get_max_index())
+        };
+        assert!(validate_red_black_tree::<TestOrderBid>(&data, root, max).is_ok());
+
+        let original = get_helper::<RBNode<TestOrderBid>>(&data, root).left;
+        get_mut_helper::<RBNode<TestOrderBid>>(&mut data, root).left = root;
+        assert!(validate_red_black_tree::<TestOrderBid>(&data, root, max).is_err());
+
+        let root_node = get_mut_helper::<RBNode<TestOrderBid>>(&mut data, root);
+        root_node.left = original;
+        root_node.color = Color(2);
+        assert!(validate_red_black_tree::<TestOrderBid>(&data, root, max).is_err());
     }
 
     #[test]

--- a/programs/manifest/tests/cases/swap.rs
+++ b/programs/manifest/tests/cases/swap.rs
@@ -4439,8 +4439,7 @@ async fn swap_across_many_reverse_orders_cu_test() -> anyhow::Result<()> {
     // simulation the full per-transaction budget so it runs to completion and we
     // can read the true cost (the default 200k budget is smaller than this whole
     // sweep).
-    let measure_limit_ix: Instruction =
-        ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+    let measure_limit_ix: Instruction = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
     let units_consumed: u64 = {
         let mut context: RefMut<ProgramTestContext> = test_fixture.context.borrow_mut();
         let blockhash: solana_program::hash::Hash =
@@ -4458,7 +4457,10 @@ async fn swap_across_many_reverse_orders_cu_test() -> anyhow::Result<()> {
             .unwrap();
         // Surface any simulation failure as a test failure with its logs.
         if let Some(Err(e)) = &sim.result {
-            panic!("swap simulation failed: {:?}\nlogs: {:?}", e, sim.simulation_details);
+            panic!(
+                "swap simulation failed: {:?}\nlogs: {:?}",
+                e, sim.simulation_details
+            );
         }
         sim.simulation_details
             .expect("simulation details present")

--- a/scripts/backfill-tickers.ts
+++ b/scripts/backfill-tickers.ts
@@ -1,11 +1,24 @@
 import { Connection, PublicKey } from '@solana/web3.js';
-import { MANIFEST_PROGRAM_ID, MARKET_DISCRIMINATOR } from './stats_utils/constants';
+import {
+  MANIFEST_PROGRAM_ID,
+  MARKET_DISCRIMINATOR,
+} from './stats_utils/constants';
 import { Market } from '../client/ts/src';
 import { getVaultAddress } from '../client/ts/src/utils';
 
-const STATS_SERVER_URL = 'https://mfx-stats-mainnet.fly.dev';
-const PRIMARY_RPC_URL = 'https://rpc.shyft.to?api_key=hji2tMNbrRzaTuyn';
-const FALLBACK_RPC_URL = 'https://rpc.shyft.to?api_key=PyFQrhOnpzF4wRAk';
+const {
+  STATS_SERVER_URL = 'https://mfx-stats-mainnet.fly.dev',
+  PRIMARY_RPC_URL,
+  FALLBACK_RPC_URL,
+  STATS_BACKFILL_API_KEY,
+} = process.env;
+
+// RPC credentials and the backfill bearer secret must never be committed.
+if (!PRIMARY_RPC_URL || !FALLBACK_RPC_URL || !STATS_BACKFILL_API_KEY) {
+  throw new Error(
+    'PRIMARY_RPC_URL, FALLBACK_RPC_URL, and STATS_BACKFILL_API_KEY are required',
+  );
+}
 
 // Rate limiting - be conservative to avoid RPC spam
 const DELAY_BETWEEN_MARKETS_MS = 500;
@@ -15,9 +28,9 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function fetchAllMarkets(connection: Connection): Promise<
-  { pubkey: PublicKey; baseVault: PublicKey }[]
-> {
+async function fetchAllMarkets(
+  connection: Connection,
+): Promise<{ pubkey: PublicKey; baseVault: PublicKey }[]> {
   console.log('Fetching all Manifest markets...');
 
   const accounts = await connection.getProgramAccounts(MANIFEST_PROGRAM_ID, {
@@ -49,7 +62,10 @@ async function fetchAllMarkets(connection: Connection): Promise<
         baseVault,
       });
     } catch (error) {
-      console.error(`Failed to deserialize market ${account.pubkey.toBase58()}:`, error);
+      console.error(
+        `Failed to deserialize market ${account.pubkey.toBase58()}:`,
+        error,
+      );
     }
   }
 
@@ -73,7 +89,10 @@ async function findFirstFillSignature(
     // Return the first signature (most recent)
     return signatures[0].signature;
   } catch (error) {
-    console.error(`Failed to get signatures for vault ${baseVault.toBase58()}:`, error);
+    console.error(
+      `Failed to get signatures for vault ${baseVault.toBase58()}:`,
+      error,
+    );
     return null;
   }
 }
@@ -83,16 +102,27 @@ async function backfillSignature(signature: string): Promise<boolean> {
 
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      const url = `${STATS_SERVER_URL}/backfill?signature=${signature}`;
-      const response = await fetch(url);
+      const url = `${STATS_SERVER_URL}/backfill`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${STATS_BACKFILL_API_KEY}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ signature }),
+      });
 
       if (!response.ok) {
         if (attempt === 0) {
-          console.error(`Backfill failed for ${signature}: ${response.status}, retrying in ${RETRY_DELAY_MS}ms...`);
+          console.error(
+            `Backfill failed for ${signature}: ${response.status}, retrying in ${RETRY_DELAY_MS}ms...`,
+          );
           await sleep(RETRY_DELAY_MS);
           continue;
         }
-        console.error(`Backfill failed for ${signature}: ${response.status} ${response.statusText}`);
+        console.error(
+          `Backfill failed for ${signature}: ${response.status} ${response.statusText}`,
+        );
         return false;
       }
 
@@ -100,7 +130,9 @@ async function backfillSignature(signature: string): Promise<boolean> {
       return result.success === true;
     } catch (error) {
       if (attempt === 0) {
-        console.error(`Failed to backfill ${signature}, retrying in ${RETRY_DELAY_MS}ms...`);
+        console.error(
+          `Failed to backfill ${signature}, retrying in ${RETRY_DELAY_MS}ms...`,
+        );
         await sleep(RETRY_DELAY_MS);
         continue;
       }
@@ -139,7 +171,10 @@ async function run() {
 
     await sleep(DELAY_BETWEEN_SIGNATURE_CHECKS_MS);
 
-    const signature = await findFirstFillSignature(connection, market.baseVault);
+    const signature = await findFirstFillSignature(
+      connection,
+      market.baseVault,
+    );
 
     if (!signature) {
       console.log('no signatures found');

--- a/scripts/liquidity-monitoring.ts
+++ b/scripts/liquidity-monitoring.ts
@@ -84,7 +84,8 @@ export class LiquidityMonitor {
     this.connection = new Connection(RPC_URL!);
     this.pool = new Pool({
       connectionString: DATABASE_URL!,
-      ssl: { rejectUnauthorized: false },
+      ssl: { rejectUnauthorized: true }, // Reject database MITM certificates.
+      statement_timeout: 15_000,
       max: 3,
       min: 1,
       idleTimeoutMillis: 20000,

--- a/scripts/orderbook-snapshots.ts
+++ b/scripts/orderbook-snapshots.ts
@@ -50,7 +50,8 @@ export class MarketMakerLeaderboard {
     this.connection = new Connection(RPC_URL!);
     this.pool = new Pool({
       connectionString: DATABASE_URL!,
-      ssl: { rejectUnauthorized: false },
+      ssl: { rejectUnauthorized: true }, // Reject database MITM certificates.
+      statement_timeout: 15_000,
       max: 10,
       min: 2,
       idleTimeoutMillis: 30000,

--- a/scripts/pk-solflare-to-phantom.ts
+++ b/scripts/pk-solflare-to-phantom.ts
@@ -27,7 +27,8 @@ if (!CHARLIE_PRIVATE_KEY) {
 }
 
 const run = async () => {
-  // iAhWd4nDdrzj1jtkceFZXhQCqH8QZF2YrVPktoLVV6ifoFqg7QqZR97mg4HwBwGWpu89uhqVr8E1VH27gsAv7ey
+  // Load secrets only from the environment; committing even example private
+  // keys gives repository readers control if the identity is still active.
   const marketCreatorPk = Keypair.fromSecretKey(
     Uint8Array.from(MARKET_CREATOR_PRIVATE_KEY.split(',').map(Number)),
   );

--- a/scripts/stats-server.ts
+++ b/scripts/stats-server.ts
@@ -17,6 +17,11 @@ import {
 import { CompleteFillsQueryOptions } from './stats_utils/types';
 import { ManifestStatsServer } from './stats_utils/manifestStatsServer';
 import { TvlMonitor } from './stats_utils/tvlMonitor';
+import {
+  isAuthorizedBearer,
+  isValidSolanaSignature,
+  parseBoundedQueryInteger,
+} from './stats_utils/httpValidation';
 
 // Global error handlers to catch unhandled errors and log them before exit
 process.on('unhandledRejection', (reason, promise) => {
@@ -34,6 +39,10 @@ process.on('uncaughtException', (error) => {
 const { READ_ONLY } = process.env;
 
 const IS_READ_ONLY = READ_ONLY === 'true';
+const BACKFILL_API_KEY = process.env.STATS_BACKFILL_API_KEY;
+if (!BACKFILL_API_KEY) {
+  throw new Error('STATS_BACKFILL_API_KEY missing from env');
+}
 if (IS_READ_ONLY) {
   console.log('⚠️  Running in READ-ONLY mode - database writes are disabled');
 }
@@ -220,8 +229,14 @@ const run = async () => {
         maker: req.query.maker as string,
         wallet: req.query.wallet as string,
         signature: req.query.signature as string,
-        limit: parseInt(req.query.limit as string) || 100,
-        offset: parseInt(req.query.offset as string) || 0,
+        limit: parseBoundedQueryInteger(req.query.limit, 100, 1, 500, 'limit'),
+        offset: parseBoundedQueryInteger(
+          req.query.offset,
+          0,
+          0,
+          10_000,
+          'offset',
+        ),
         fromSlot: req.query.fromSlot
           ? parseInt(req.query.fromSlot as string)
           : undefined,
@@ -234,6 +249,10 @@ const run = async () => {
       res.send(result);
     } catch (error) {
       console.error('Error in completeFills handler:', error);
+      if (error instanceof RangeError) {
+        res.status(400).send({ error: error.message });
+        return;
+      }
       res.status(500).send({ error: 'Internal server error' });
     }
   };
@@ -250,14 +269,29 @@ const run = async () => {
     res.send(statsServer.getCheckpointStatus());
   };
 
+  // Backfills trigger expensive RPC/database work. Authentication plus a small
+  // in-process queue prevents the endpoint from being used for resource abuse.
+  const activeBackfills = new Set<string>();
   const backfillHandler: RequestHandler = async (req, res) => {
+    if (!isAuthorizedBearer(req.header('authorization'), BACKFILL_API_KEY)) {
+      res.status(401).send({ error: 'Unauthorized' });
+      return;
+    }
+    const signature = req.body?.signature;
+    if (!isValidSolanaSignature(signature)) {
+      res.status(400).send({ error: 'A valid signature is required' });
+      return;
+    }
+    if (activeBackfills.has(signature)) {
+      res.status(409).send({ error: 'Backfill already in progress' });
+      return;
+    }
+    if (activeBackfills.size >= 2) {
+      res.status(429).send({ error: 'Backfill queue is full' });
+      return;
+    }
+    activeBackfills.add(signature);
     try {
-      const signature = req.query.signature as string;
-      if (!signature) {
-        res.status(400).send({ error: 'signature parameter is required' });
-        return;
-      }
-
       const result = await statsServer.backfillTransaction(signature);
       res.send({
         success: true,
@@ -268,6 +302,8 @@ const run = async () => {
     } catch (error) {
       console.error('Error in backfill handler:', error);
       res.status(500).send({ error: 'Internal server error' });
+    } finally {
+      activeBackfills.delete(signature);
     }
   };
 
@@ -291,6 +327,7 @@ const run = async () => {
   };
 
   const app = express();
+  app.use(express.json({ limit: '4kb' }));
   app.use(cors());
 
   // HTTP request metrics middleware - tracks latency and status codes per endpoint
@@ -340,7 +377,7 @@ const run = async () => {
   app.get('/notional', notionalHandler);
   app.get('/checkpoints', checkpointsHandler);
   app.get('/checkpointStatus', checkpointStatusHandler);
-  app.get('/backfill', backfillHandler);
+  app.post('/backfill', backfillHandler);
   app.get('/wrapper', wrapperHandler);
   app.get('/wrappers', wrappersHandler);
 

--- a/scripts/stats_utils/httpValidation.ts
+++ b/scripts/stats_utils/httpValidation.ts
@@ -1,0 +1,46 @@
+import { timingSafeEqual } from 'crypto';
+
+export function parseBoundedQueryInteger(
+  value: unknown,
+  defaultValue: number,
+  minimum: number,
+  maximum: number,
+  name: string,
+): number {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new RangeError(
+      `${name} must be an integer between ${minimum} and ${maximum}`,
+    );
+  }
+  return parsed;
+}
+
+export function isAuthorizedBearer(
+  authorization: string | undefined,
+  expectedToken: string,
+): boolean {
+  if (!authorization?.startsWith('Bearer ') || expectedToken.length === 0) {
+    return false;
+  }
+  const supplied = Buffer.from(authorization.slice('Bearer '.length));
+  const expected = Buffer.from(expectedToken);
+  return (
+    supplied.length === expected.length && timingSafeEqual(supplied, expected)
+  );
+}
+
+export function isValidSolanaSignature(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length >= 64 &&
+    value.length <= 88 &&
+    /^[1-9A-HJ-NP-Za-km-z]+$/.test(value)
+  );
+}

--- a/scripts/stats_utils/manifestStatsServer.ts
+++ b/scripts/stats_utils/manifestStatsServer.ts
@@ -283,7 +283,9 @@ export class ManifestStatsServer {
 
     this.pool = new Pool({
       connectionString: databaseUrl,
-      ssl: { rejectUnauthorized: false }, // May be needed depending on Fly Postgres configuration
+      // Never silently accept a forged database certificate.
+      ssl: { rejectUnauthorized: true },
+      statement_timeout: 15_000,
     });
 
     this.pool.on('error', (err) => {
@@ -1945,6 +1947,13 @@ export class ManifestStatsServer {
       offset = 0,
       toSlot,
     } = options;
+    // Bound pagination before building the query to prevent oversized scans.
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 500) {
+      throw new RangeError('limit must be an integer between 1 and 500');
+    }
+    if (!Number.isSafeInteger(offset) || offset < 0 || offset > 10_000) {
+      throw new RangeError('offset must be an integer between 0 and 10000');
+    }
 
     // Apply default slot filter only if no efficient index filter is present
     const hasEfficientFilter = market || signature || taker || maker;

--- a/scripts/update-alts.ts
+++ b/scripts/update-alts.ts
@@ -194,7 +194,8 @@ async function main() {
   const connection = new Connection(RPC_URL!, 'confirmed');
   const pool = new Pool({
     connectionString: DATABASE_URL!,
-    ssl: { rejectUnauthorized: false }, // May be needed depending on Fly Postgres configuration
+    ssl: { rejectUnauthorized: true }, // Reject database MITM certificates.
+    statement_timeout: 15_000,
   });
   const keypair = Keypair.fromSecretKey(
     Uint8Array.from(PRIVATE_KEY!.split(',').map(Number)),


### PR DESCRIPTION
Bind fill parsing and reconciliation to Manifest invocation frames, cap block and WebSocket resource use, and authenticate and bound stats endpoints.

Validate untrusted Rust and TypeScript account trees, remove unsafe enum and alignment assumptions, handle malformed Jupiter and OKX inputs, enforce database TLS, and remove committed credentials.

Add regression coverage for log attribution, reconciliation, HTTP validation, and hostile tree data, and archive the full Codex CLI findings.